### PR TITLE
chore: prepare v0.2.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable project changes should be documented here.
 
 ## Unreleased
 
+## 0.2.1
+
+### Added
+
+- Convert HEIC and HEIF photos, including iPhone and iPad images, to PDF entirely offline with a bundled decoder.
+
 ## 0.2.0
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "offpdf",
-  "version": "0.1.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "offpdf",
-      "version": "0.1.0",
+      "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
         "@tauri-apps/api": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "offpdf",
   "private": true,
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "module",
   "description": "Free, open-source, offline-first desktop PDF utility.",
   "license": "MIT",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2848,7 +2848,7 @@ dependencies = [
 
 [[package]]
 name = "offpdf"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "fs2",
  "heif-rs",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "offpdf"
-version = "0.2.0"
+version = "0.2.1"
 description = "Free, open-source, offline-first desktop PDF utility."
 authors = ["OffPDF contributors"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "OffPDF",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "identifier": "app.offpdf.desktop",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Summary

- bump desktop and Tauri package versions to 0.2.1
- document offline HEIC/HEIF-to-PDF support in the changelog
- align the npm lockfile package version

## Validation

- [x] HEIC feature PR CI passed
- [x] version values aligned across manifests