### PR TITLE
fix: bundle Windows runtime required at startup

### DIFF
--- a/.github/workflows/windows-release.yml
+++ b/.github/workflows/windows-release.yml
@@ -84,6 +84,28 @@ jobs:
           prerelease: false
           args: --bundles nsis
 
+      - name: Smoke test installed application
+        shell: pwsh
+        run: |
+          $installer = Get-ChildItem -Path src-tauri/target/release/bundle/nsis -Filter '*-setup.exe' | Select-Object -First 1
+          if (-not $installer) { throw 'NSIS installer was not produced.' }
+
+          $process = Start-Process -FilePath $installer.FullName -ArgumentList '/S' -Wait -PassThru
+          if ($process.ExitCode -ne 0) { throw "Silent install failed with exit code $($process.ExitCode)." }
+
+          $appPath = Join-Path $env:LOCALAPPDATA 'OffPDF\offpdf.exe'
+          if (-not (Test-Path $appPath)) { throw "Installed application not found at $appPath" }
+
+          foreach ($runtime in @('msvcp140.dll', 'vcruntime140.dll', 'vcruntime140_1.dll')) {
+            $runtimePath = Join-Path (Split-Path $appPath) $runtime
+            if (-not (Test-Path $runtimePath)) { throw "Required runtime is missing: $runtimePath" }
+          }
+
+          $app = Start-Process -FilePath $appPath -PassThru
+          Start-Sleep -Seconds 10
+          if ($app.HasExited) { throw "OffPDF exited during startup with code $($app.ExitCode)." }
+          Stop-Process -Id $app.Id -Force
+
       - name: List bundle outputs
         shell: pwsh
         run: Get-ChildItem -Path src-tauri/target/release/bundle -Recurse | Select-Object FullName, Length

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable project changes should be documented here.
 
 ## Unreleased
 
+## 0.2.2
+
+### Fixed
+
+- Windows: bundle the Microsoft Visual C++ runtime beside the application so OffPDF starts on clean Windows installations after HEIC/HEIF support was added.
+- Windows release builds now install and launch the packaged application as a smoke test before publishing it.
+
 ## 0.2.1
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "offpdf",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "offpdf",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "MIT",
       "dependencies": {
         "@tauri-apps/api": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "offpdf",
   "private": true,
-  "version": "0.2.1",
+  "version": "0.2.2",
   "type": "module",
   "description": "Free, open-source, offline-first desktop PDF utility.",
   "license": "MIT",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2848,7 +2848,7 @@ dependencies = [
 
 [[package]]
 name = "offpdf"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "fs2",
  "heif-rs",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "offpdf"
-version = "0.2.1"
+version = "0.2.2"
 description = "Free, open-source, offline-first desktop PDF utility."
 authors = ["OffPDF contributors"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "OffPDF",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "identifier": "app.offpdf.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src-tauri/tauri.windows.conf.json
+++ b/src-tauri/tauri.windows.conf.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://schema.tauri.app/config/2",
+  "bundle": {
+    "resources": {
+      "binaries/msvcp140.dll": "msvcp140.dll",
+      "binaries/vcruntime140.dll": "vcruntime140.dll",
+      "binaries/vcruntime140_1.dll": "vcruntime140_1.dll"
+    }
+  }
+}


### PR DESCRIPTION
## Root cause

The HEIC decoder added in v0.2.1 makes `offpdf.exe` import `MSVCP140.dll`. The Windows installer contained the Visual C++ runtime only under `binaries/`, but the Windows loader needs it beside `offpdf.exe` before any application code can run. Clean Windows machines therefore exited before opening a window.

## Fix

- bundle MSVCP140 and its VCRUNTIME dependencies beside the main executable on Windows
- keep the resource mapping Windows-only so macOS builds remain portable
- install and launch the packaged NSIS application in CI before publishing
- prepare patch release v0.2.2

## Validation

- [x] frontend production build
- [x] 21 frontend tests
- [x] Rust check
- [x] verified v0.2.1 executable imports MSVCP140.dll while installer placed it in the wrong directory
- [ ] packaged Windows launch smoke test (release workflow)