### PR TITLE
fix output name length validation

### DIFF
--- a/src/lib/validation.test.ts
+++ b/src/lib/validation.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { validateOutputName } from "./validation";
+
+describe("validateOutputName", () => {
+  it("appends .pdf and enforces the 200-character limit on the normalized name", () => {
+    expect(validateOutputName("a".repeat(196))).toEqual({
+      ok: true,
+      value: "a".repeat(196) + ".pdf",
+    });
+    expect(validateOutputName("a".repeat(197))).toEqual({
+      ok: false,
+      error: "That file name is too long.",
+    });
+  });
+
+  it("does not append .pdf when the name already ends in it", () => {
+    expect(validateOutputName("report.PDF")).toEqual({ ok: true, value: "report.PDF" });
+    expect(validateOutputName("a".repeat(196) + ".pdf")).toEqual({
+      ok: true,
+      value: "a".repeat(196) + ".pdf",
+    });
+  });
+
+  it("still rejects empty, invalid-character and reserved names", () => {
+    expect(validateOutputName("  ")).toEqual({ ok: false, error: "Enter an output file name." });
+    expect(validateOutputName("a<b")).toEqual({
+      ok: false,
+      error: 'A file name cannot contain: < > : " / \\ | ? *',
+    });
+    expect(validateOutputName("con")).toEqual({
+      ok: false,
+      error: "“con” is a reserved name on Windows.",
+    });
+  });
+});

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -46,10 +46,10 @@ export function validateOutputName(name: string): NameValidation {
   if (RESERVED_WINDOWS_NAMES.test(trimmed)) {
     return { ok: false, error: `“${trimmed}” is a reserved name on Windows.` };
   }
-  if (trimmed.length > 200) {
+  const withExt = /\.pdf$/i.test(trimmed) ? trimmed : `${trimmed}.pdf`;
+  if (withExt.length > 200) {
     return { ok: false, error: "That file name is too long." };
   }
-  const withExt = /\.pdf$/i.test(trimmed) ? trimmed : `${trimmed}.pdf`;
   return { ok: true, value: withExt };
 }
 


### PR DESCRIPTION
## Summary

Validate the output name after applying the `.pdf` normalization so names that exceed the 200-character limit after normalization are rejected.

## Testing

- added coverage for the Issue #22 boundary cases
- existing tests pass

Closes #22
