### PR TITLE
chore: prepare OffPDF v0.3.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -31,7 +31,7 @@ body:
     id: version
     attributes:
       label: OffPDF version
-      placeholder: v0.2.2 or commit SHA
+      placeholder: v0.3.0 or commit SHA
     validations:
       required: false
   - type: dropdown

--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -13,6 +13,7 @@ concurrency:
 jobs:
   macos-arm64:
     name: Build, sign, and notarize macOS arm64
+    if: github.ref == 'refs/heads/main'
     runs-on: macos-15
     timeout-minutes: 120
     env:
@@ -94,10 +95,25 @@ jobs:
           tagName: v__VERSION__
           releaseName: OffPDF v__VERSION__
           releaseBody: |
-            Signed and notarized OffPDF build for Apple Silicon Macs.
+            OffPDF now includes 23 private PDF tools that run locally without
+            uploads, accounts, or telemetry.
 
-            Supported: M1, M2, M3, M4 and newer Apple Silicon processors.
-            LibreOffice is optional and only required for Office conversion tools.
+            Highlights:
+            - Edit PDF adds text, images, shapes, lines, and freehand drawings
+              without rasterizing the original document.
+            - Cropped, rotated, and scaled pages preserve source content and
+              overlay placement.
+            - Reader accessibility, output-name validation, and metadata text
+              decoding are improved.
+
+            Thanks to @nonamexishere, @YuukiRitoTeng, @strongdan, and @joyheroes
+            for contributing to this release.
+
+            Packages:
+            - Windows x64 installer (currently unsigned; SmartScreen may warn)
+            - Signed and notarized DMG for Apple Silicon Macs
+
+            See CHANGELOG.md for full details.
           releaseDraft: true
           prerelease: false
           args: --target aarch64-apple-darwin --bundles dmg

--- a/.github/workflows/windows-release.yml
+++ b/.github/workflows/windows-release.yml
@@ -30,6 +30,7 @@ concurrency:
 jobs:
   windows-x64:
     name: Build and release Windows installer
+    if: github.ref == 'refs/heads/main'
     runs-on: windows-latest
     timeout-minutes: 120
 
@@ -73,13 +74,25 @@ jobs:
           tagName: v__VERSION__
           releaseName: OffPDF v__VERSION__
           releaseBody: |
-            OffPDF build for Windows (x64).
+            OffPDF now includes 23 private PDF tools that run locally without
+            uploads, accounts, or telemetry.
 
-            Note: this installer is not code-signed yet, so Windows SmartScreen
-            may show an "unknown publisher" warning. Click "More info" then
-            "Run anyway" to install.
+            Highlights:
+            - Edit PDF adds text, images, shapes, lines, and freehand drawings
+              without rasterizing the original document.
+            - Cropped, rotated, and scaled pages preserve source content and
+              overlay placement.
+            - Reader accessibility, output-name validation, and metadata text
+              decoding are improved.
 
-            LibreOffice is bundled and only required for Office conversion tools.
+            Thanks to @nonamexishere, @YuukiRitoTeng, @strongdan, and @joyheroes
+            for contributing to this release.
+
+            Packages:
+            - Windows x64 installer (currently unsigned; SmartScreen may warn)
+            - Signed and notarized DMG for Apple Silicon Macs
+
+            See CHANGELOG.md for full details.
           releaseDraft: true
           prerelease: false
           args: --bundles nsis

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable project changes should be documented here.
 
 ## Unreleased
 
+## 0.3.0 - 2026-08-15
+
 ### Added
 
 - Edit PDF: add text (including Turkish), PNG/JPEG images, rectangles, lines and freehand drawings on a live page preview. Saves a new overlay PDF via qpdf; the original file is never overwritten. Noto Sans is bundled (SIL OFL) for Unicode overlay text.
@@ -14,10 +16,19 @@ All notable project changes should be documented here.
 
 - Edit PDF: saving keeps the original as qpdf's primary input, so bookmarks, document metadata, and forms survive a single-file export. Multi-file edits keep catalog data from the first file (same as Optimize).
 - Edit PDF: the never-overwrite guard compares file identity (not just path), and save writes to a sibling temp file then renames it into place so a hard-linked output path cannot truncate the original.
-- Edit PDF: preview and export share one geometry model — qpdf overlay aligns to TrimBox (then CropBox/MediaBox), `/UserUnit` is honored, and images on 90°/270° pages keep the same aspect as the preview.
+- Edit PDF: preview and export share one visible-page geometry model. Offset CropBox/TrimBox pages, `/UserUnit`, and 0°/90°/180°/270° rotation preserve both original content and overlay placement.
 - Edit PDF: preview and save share the same image limits (20 MB, 4096 px on a side). Oversized files are rejected from headers before decode; the same image used twice is embedded once; a document-wide byte/pixel budget applies; save can cancel between images.
 - Edit PDF: adding or removing a workspace PDF remaps edits by page identity instead of clearing the canvas. Removing a PDF that still has edits asks first.
 - Page preview uses a grab cursor for drag-to-pan instead of a zoom-in magnifier. Zoom stays on the toolbar, keyboard shortcuts, and Ctrl/Cmd + wheel.
+- Edit PDF keeps selection, copy, delete, duplicate, drag, and arrow-key movement on the active page; hidden-page objects are not changed.
+- Edit PDF keeps both edges reachable at high zoom and places output settings, save progress, cancellation, and completed-file actions before the canvas.
+- The full-page reader now exposes accessible names for icon-only controls, search, and page thumbnails.
+- Output file names enforce the 200-character limit after adding the `.pdf` extension.
+- Metadata and bookmark titles decode PDFDocEncoding punctuation and symbols correctly.
+
+### Contributors
+
+- Thank you to @nonamexishere, @YuukiRitoTeng, @strongdan, and @joyheroes for their contributions to this release.
 
 ## 0.2.2
 

--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ service in the middle.
 
 | Platform | Package | Status |
 | --- | --- | --- |
-| Windows x64 | [Download v0.2.2 setup](https://github.com/McanKul/offpdf/releases/download/v0.2.2/OffPDF_0.2.2_x64-setup.exe) | Available; currently unsigned, so SmartScreen may warn |
-| macOS 11+ · Apple Silicon | [Download v0.2.2 DMG](https://github.com/McanKul/offpdf/releases/download/v0.2.2/OffPDF_0.2.2_aarch64.dmg) | Signed and notarized |
+| Windows x64 | [Download from the latest release](https://github.com/McanKul/offpdf/releases/latest) | Available; currently unsigned, so SmartScreen may warn |
+| macOS 11+ · Apple Silicon | [Download from the latest release](https://github.com/McanKul/offpdf/releases/latest) | Signed and notarized |
 | Intel Mac / Linux | [Build from source](#development) | No published package yet |
 
 The Windows installer is large because it includes the local engines needed to

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -5,7 +5,7 @@ reliable local processing, clear packaging, and a contributor-friendly project.
 
 ## Current release
 
-- **v0.2.2** is the latest public release, distributed through GitHub Releases
+- **v0.3.0** is the latest public release, distributed through GitHub Releases
   and [offpdf.com](https://offpdf.com).
 - The Windows x64 installer bundles qpdf, Poppler, Tesseract, and LibreOffice so
   the supported workflows run offline. The installer is not code-signed yet.
@@ -38,6 +38,8 @@ reliable local processing, clear packaging, and a contributor-friendly project.
 - Lossy compression rasterizes pages. Use text-preserving compression when text
   selection matters.
 - Complex Office conversions are best effort and may not reproduce every layout.
+- Edit PDF adds new text, images, and shapes as overlays; it does not rewrite
+  existing text or images inside the source document.
 - Auto-update is intentionally not enabled.
 
 ## Later

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "offpdf",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "offpdf",
-      "version": "0.2.2",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@tauri-apps/api": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "offpdf",
   "private": true,
-  "version": "0.2.2",
+  "version": "0.3.0",
   "type": "module",
   "description": "Free, open-source, offline-first desktop PDF utility.",
   "license": "MIT",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2848,7 +2848,7 @@ dependencies = [
 
 [[package]]
 name = "offpdf"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "fs2",
  "heif-rs",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "offpdf"
-version = "0.2.2"
+version = "0.3.0"
 description = "Free, open-source, offline-first desktop PDF utility."
 authors = ["OffPDF contributors"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "OffPDF",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "identifier": "app.offpdf.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/routes/SettingsPage.tsx
+++ b/src/routes/SettingsPage.tsx
@@ -22,7 +22,7 @@ export function SettingsPage() {
   const [clearing, setClearing] = useState(false);
 
   useEffect(() => {
-    getVersion().then(setVersion).catch(() => setVersion("0.1.0"));
+    getVersion().then(setVersion).catch(() => setVersion("—"));
     getTempDir().then(setTempDir).catch(() => setTempDir(""));
   }, []);
 
@@ -119,7 +119,7 @@ export function SettingsPage() {
             <div className="setting-row__label">App version</div>
             <div className="setting-row__desc">OffPDF — local-first PDF utility.</div>
           </div>
-          <Badge variant="neutral">v{version}</Badge>
+          <Badge variant="neutral">{version === "—" ? version : `v${version}`}</Badge>
         </div>
       </Card>
 


### PR DESCRIPTION
## Summary

Prepare `development` for the v0.3.0 release: synchronize npm, Cargo, and Tauri versions; finalize release notes; refresh download and roadmap copy; and prevent release workflows from running outside `main`.

### Release highlights

- New Edit PDF workflow with text, images, shapes, drawing, live preview, zoom, and pan
- Safer exports that preserve source structure, page boxes, rotation, and `/UserUnit`
- Better reader accessibility, filename validation, metadata/bookmark decoding, and regression coverage

## Verification

- [x] `actionlint .github/workflows/*.yml`
- [x] `npm test` — 146 tests
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `cargo check --manifest-path src-tauri/Cargo.toml`
- [x] `cargo test --manifest-path src-tauri/Cargo.toml --lib` — 90 tests
- [ ] Required GitHub checks are green

## Contributors

Thanks to @nonamexishere, @joyheroes, @strongdan, and @YuukiRitoTeng for their work in this release.