### PR TITLE
fix: harden HEIC imports and v0.3 release gates

### DIFF
--- a/.github/release-notes/v0.3.0.md
+++ b/.github/release-notes/v0.3.0.md
@@ -1,0 +1,23 @@
+OffPDF now includes 23 private PDF tools that run locally without uploads,
+accounts, or telemetry.
+
+Highlights:
+
+- Edit PDF adds text, images, shapes, lines, and freehand drawings without
+  rasterizing the original document.
+- Cropped, rotated, and scaled pages preserve source content and overlay
+  placement.
+- HEIC/HEIF imports are bounded and serialized to avoid memory-related crashes.
+- Reader accessibility, output-name validation, and metadata text decoding are
+  improved.
+
+Thanks to @nonamexishere, @YuukiRitoTeng, @strongdan, and @joyheroes for
+contributing to this release.
+
+Packages:
+
+- Signed and notarized DMG for Apple Silicon Macs
+- Windows is withheld until the Authenticode signing workflow is ready
+
+See [CHANGELOG.md](https://github.com/McanKul/offpdf/blob/v0.3.0/CHANGELOG.md)
+for full details.

--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -39,6 +39,9 @@ jobs:
       - name: Install frontend dependencies
         run: npm ci
 
+      - name: Smoke test HEIC and HEIF conversion
+        run: cargo test --manifest-path src-tauri/Cargo.toml --lib heic_and_heif_complete_the_jpeg_and_pdf_pipeline
+
       - name: Install macOS PDF engines
         env:
           HOMEBREW_NO_AUTO_UPDATE: "1"
@@ -89,33 +92,7 @@ jobs:
 
       - name: Build signed and notarized DMG
         uses: tauri-apps/tauri-action@v0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tagName: v__VERSION__
-          releaseName: OffPDF v__VERSION__
-          releaseBody: |
-            OffPDF now includes 23 private PDF tools that run locally without
-            uploads, accounts, or telemetry.
-
-            Highlights:
-            - Edit PDF adds text, images, shapes, lines, and freehand drawings
-              without rasterizing the original document.
-            - Cropped, rotated, and scaled pages preserve source content and
-              overlay placement.
-            - Reader accessibility, output-name validation, and metadata text
-              decoding are improved.
-
-            Thanks to @nonamexishere, @YuukiRitoTeng, @strongdan, and @joyheroes
-            for contributing to this release.
-
-            Packages:
-            - Windows x64 installer (currently unsigned; SmartScreen may warn)
-            - Signed and notarized DMG for Apple Silicon Macs
-
-            See CHANGELOG.md for full details.
-          releaseDraft: true
-          prerelease: false
           args: --target aarch64-apple-darwin --bundles dmg
 
       - name: Verify application signature and notarization ticket
@@ -135,3 +112,43 @@ jobs:
           codesign --verify --deep --strict --verbose=2 "$app_path"
           spctl --assess --type execute --verbose=2 "$app_path"
           xcrun stapler validate "$app_path"
+
+      - name: Attach verified DMG to draft release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          version="$(node -p "require('./package.json').version")"
+          tag="v${version}"
+          notes_path=".github/release-notes/${tag}.md"
+          dmg_path="$(find src-tauri/target/aarch64-apple-darwin/release/bundle/dmg -maxdepth 1 -name '*.dmg' -print -quit)"
+          test -f "$notes_path"
+          test -n "$dmg_path"
+
+          if gh release view "$tag" --json isDraft >/dev/null 2>&1; then
+            is_draft="$(gh release view "$tag" --json isDraft --jq '.isDraft')"
+            if [[ "$is_draft" != "true" ]]; then
+              echo "Refusing to replace assets on published release $tag." >&2
+              exit 1
+            fi
+            tag_sha="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${tag}" --jq '.sha')"
+            if [[ "$tag_sha" != "$GITHUB_SHA" ]]; then
+              echo "Refusing to attach a build from $GITHUB_SHA to $tag at $tag_sha." >&2
+              exit 1
+            fi
+            gh release upload "$tag" "$dmg_path" --clobber
+            gh release edit "$tag" \
+              --title "OffPDF ${tag}" \
+              --notes-file "$notes_path"
+          else
+            if tag_sha="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${tag}" --jq '.sha' 2>/dev/null)"; then
+              if [[ "$tag_sha" != "$GITHUB_SHA" ]]; then
+                echo "Refusing to create a release for $tag at $tag_sha from $GITHUB_SHA." >&2
+                exit 1
+              fi
+            fi
+            gh release create "$tag" "$dmg_path" \
+              --draft \
+              --target "$GITHUB_SHA" \
+              --title "OffPDF ${tag}" \
+              --notes-file "$notes_path"
+          fi

--- a/.github/workflows/windows-release.yml
+++ b/.github/workflows/windows-release.yml
@@ -1,4 +1,4 @@
-name: Windows Release
+name: Windows Build Verification
 
 on:
   workflow_dispatch:
@@ -21,7 +21,7 @@ on:
         type: string
 
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
   group: windows-release-${{ github.ref }}
@@ -29,8 +29,8 @@ concurrency:
 
 jobs:
   windows-x64:
-    name: Build and release Windows installer
-    if: github.ref == 'refs/heads/main'
+    name: Build and smoke-test Windows installer (not published)
+    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/development'
     runs-on: windows-latest
     timeout-minutes: 120
 
@@ -50,6 +50,9 @@ jobs:
       - name: Install frontend dependencies
         run: npm ci
 
+      - name: Smoke test HEIC and HEIF conversion
+        run: cargo test --manifest-path src-tauri/Cargo.toml --lib heic_and_heif_complete_the_jpeg_and_pdf_pipeline
+
       - name: Bundle qpdf for Windows
         shell: pwsh
         run: ./scripts/prepare-qpdf-windows.ps1 -Version "${{ github.event.inputs.qpdf_version }}"
@@ -66,36 +69,16 @@ jobs:
         shell: pwsh
         run: ./scripts/prepare-libreoffice-windows.ps1 -Version "${{ github.event.inputs.libreoffice_version }}"
 
-      - name: Build and release Windows installer
+      - name: Build Windows installer for smoke testing
         uses: tauri-apps/tauri-action@v0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tagName: v__VERSION__
-          releaseName: OffPDF v__VERSION__
-          releaseBody: |
-            OffPDF now includes 23 private PDF tools that run locally without
-            uploads, accounts, or telemetry.
-
-            Highlights:
-            - Edit PDF adds text, images, shapes, lines, and freehand drawings
-              without rasterizing the original document.
-            - Cropped, rotated, and scaled pages preserve source content and
-              overlay placement.
-            - Reader accessibility, output-name validation, and metadata text
-              decoding are improved.
-
-            Thanks to @nonamexishere, @YuukiRitoTeng, @strongdan, and @joyheroes
-            for contributing to this release.
-
-            Packages:
-            - Windows x64 installer (currently unsigned; SmartScreen may warn)
-            - Signed and notarized DMG for Apple Silicon Macs
-
-            See CHANGELOG.md for full details.
-          releaseDraft: true
-          prerelease: false
           args: --bundles nsis
+
+      - name: Enforce Windows signing gate
+        shell: pwsh
+        run: |
+          Write-Host 'This workflow validates the Windows bundle locally only.'
+          Write-Host 'Do not publish it until the Authenticode signing workflow is enabled.'
 
       - name: Smoke test installed application
         shell: pwsh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,10 +25,15 @@ All notable project changes should be documented here.
 - The full-page reader now exposes accessible names for icon-only controls, search, and page thumbnails.
 - Output file names enforce the 200-character limit after adding the `.pdf` extension.
 - Metadata and bookmark titles decode PDFDocEncoding punctuation and symbols correctly.
+- HEIC/HEIF imports validate compressed size and image dimensions before native decoding, avoid an extra full-size RGB copy, and run image conversions serially so large batches cannot multiply peak memory use.
 
 ### Contributors
 
 - Thank you to @nonamexishere, @YuukiRitoTeng, @strongdan, and @joyheroes for their contributions to this release.
+
+### Distribution
+
+- New Windows packages are withheld until the Authenticode signing and verification workflow is ready. The manual Windows workflow now builds and smoke-tests locally without attaching an unsigned installer to a GitHub Release.
 
 ## 0.2.2
 

--- a/CODE_SIGNING_POLICY.md
+++ b/CODE_SIGNING_POLICY.md
@@ -1,0 +1,40 @@
+# Code signing policy
+
+OffPDF publishes release artifacts only from the protected `main` branch through
+the GitHub Actions workflows stored in this repository. A source commit, release
+tag, build log, and resulting artifact must remain traceable to one another.
+
+## Current platform policy
+
+- Apple Silicon macOS releases are signed with an Apple Developer ID certificate,
+  notarized by Apple, and verified before publication.
+- Public Windows distribution is paused while the Authenticode signing workflow
+  is being prepared. An unsigned Windows validation build must not be attached to
+  a public GitHub Release or linked as an official download.
+- Windows publication will resume only after the application executable,
+  installer, and uninstaller pass Authenticode and timestamp verification.
+
+## Roles and approval
+
+- Contributors submit changes through pull requests against `development`.
+- Repository maintainer `@McanKul` reviews release integration and is the current
+  signing-policy approver.
+- Signing credentials are restricted to GitHub Actions secrets or the signing
+  provider. They are never committed to the repository or exposed to pull
+  request workflows.
+- Every production signing request requires explicit maintainer approval.
+
+## Release controls
+
+1. Required frontend and Rust checks must pass on the release commit.
+2. Release builds run on GitHub-hosted runners from the tagged `main` commit.
+3. Each platform workflow completes its explicitly documented signature,
+   notarization, and smoke-test gates before it can attach a release artifact.
+4. The future Windows workflow must additionally verify the application,
+   installer, uninstaller, and RFC 3161 timestamp before publishing anything.
+5. A failed or unverifiable artifact is discarded rather than published.
+
+OffPDF has no automatic updater. Users choose when to download and install a
+release. See the [privacy statement](./PRIVACY.md), the
+[uninstall instructions](https://offpdf.com/uninstall), and the
+[security policy](./SECURITY.md) for related project policies.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 </p>
 
 <p align="center">
-  <strong><a href="https://github.com/McanKul/offpdf/releases/latest">Download the latest release</a></strong>
+  <strong><a href="#downloads">View downloads</a></strong>
   · <a href="https://offpdf.com">Visit offpdf.com</a>
   · <a href="./CONTRIBUTING.md">Contribute</a>
 </p>
@@ -60,7 +60,7 @@ service in the middle.
 
 | Platform | Package | Status |
 | --- | --- | --- |
-| Windows x64 | [Download from the latest release](https://github.com/McanKul/offpdf/releases/latest) | Available; currently unsigned, so SmartScreen may warn |
+| Windows x64 | New package not currently published | v0.3 is withheld while Authenticode signing is prepared; older unsigned builds remain in release history |
 | macOS 11+ · Apple Silicon | [Download from the latest release](https://github.com/McanKul/offpdf/releases/latest) | Signed and notarized |
 | Intel Mac / Linux | [Build from source](#development) | No published package yet |
 
@@ -70,6 +70,9 @@ Tesseract; LibreOffice is optional and only needed for Office and PDF/A tools.
 
 All published binaries are available on the
 [Releases page](https://github.com/McanKul/offpdf/releases).
+
+See the [code signing policy](./CODE_SIGNING_POLICY.md) for how official release
+artifacts are built, approved, and verified.
 
 ## Privacy model
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -5,12 +5,18 @@ reliable local processing, clear packaging, and a contributor-friendly project.
 
 ## Current release
 
-- **v0.3.0** is the latest public release, distributed through GitHub Releases
-  and [offpdf.com](https://offpdf.com).
-- The Windows x64 installer bundles qpdf, Poppler, Tesseract, and LibreOffice so
-  the supported workflows run offline. The installer is not code-signed yet.
+- **v0.2.2** is the latest published release. Its historical Windows package is
+  unsigned; new Windows distribution is paused rather than repeating that model.
 - The Apple Silicon macOS build is signed and notarized. It bundles qpdf,
   Poppler, and Tesseract; LibreOffice remains optional for Office and PDF/A work.
+
+## Next release
+
+- **v0.3.0** is being prepared for distribution through GitHub Releases and
+  [offpdf.com](https://offpdf.com).
+- The Windows x64 installer bundles qpdf, Poppler, Tesseract, and LibreOffice so
+  the supported workflows run offline. Public Windows distribution is paused
+  until the Authenticode signing workflow is ready.
 - The app currently includes 23 tools for organizing, converting, optimizing,
   securing, and repairing PDFs.
 
@@ -32,7 +38,7 @@ reliable local processing, clear packaging, and a contributor-friendly project.
 
 ## Known limitations
 
-- Windows may display a SmartScreen warning because the installer is unsigned.
+- A current Windows installer is not published while code signing is being set up.
 - There are no official Intel Mac or Linux packages yet.
 - Office conversion and PDF/A require LibreOffice; it is not bundled on macOS.
 - Lossy compression rasterizes pages. Use text-preserving compression when text

--- a/src-tauri/src/pdf_engine/compress.rs
+++ b/src-tauri/src/pdf_engine/compress.rs
@@ -16,8 +16,10 @@ use crate::error::AppError;
 use crate::models::{JobHandle, JobUpdate};
 use crate::pdf_engine::render;
 use crate::utils::temp;
+use std::io::{self, Read};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use tauri::Emitter;
 
@@ -139,12 +141,89 @@ pub(crate) struct PageImage {
     pub dpi: u32,
 }
 
+const MAX_HEIF_FILE_BYTES: u64 = 64 * 1024 * 1024;
+const MAX_HEIF_EDGE: u32 = 8_192;
+const MAX_HEIF_PIXELS: u64 = 32_000_000;
+const MAX_HEIF_DECODED_BYTES: u64 = 128 * 1024 * 1024;
+
+struct BoundedReader<R> {
+    inner: R,
+    remaining: u64,
+    exceeded: Arc<AtomicBool>,
+}
+
+impl<R> BoundedReader<R> {
+    fn new(inner: R, limit: u64, exceeded: Arc<AtomicBool>) -> Self {
+        Self {
+            inner,
+            remaining: limit,
+            exceeded,
+        }
+    }
+}
+
+impl<R: Read> Read for BoundedReader<R> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        if buf.is_empty() {
+            return Ok(0);
+        }
+        if self.remaining == 0 {
+            let mut extra = [0u8; 1];
+            return match self.inner.read(&mut extra) {
+                Ok(0) => Ok(0),
+                Ok(_) => {
+                    self.exceeded.store(true, Ordering::Relaxed);
+                    Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "HEIC/HEIF file exceeds the safe byte limit",
+                    ))
+                }
+                Err(error) => Err(error),
+            };
+        }
+
+        let allowed = usize::try_from(self.remaining.min(buf.len() as u64)).unwrap_or(buf.len());
+        let read = self.inner.read(&mut buf[..allowed])?;
+        self.remaining -= read as u64;
+        Ok(read)
+    }
+}
+
+fn heif_too_large() -> AppError {
+    AppError::new(
+        "IMAGE_TOO_LARGE",
+        "Image is too large",
+        "This HEIC/HEIF image is too large to convert safely.",
+    )
+    .with_suggestion("Export a smaller copy of the photo and try again.")
+}
+
+fn validate_heif_limits(
+    file_len: u64,
+    width: u32,
+    height: u32,
+    decoded_bytes: u64,
+) -> Result<(), AppError> {
+    let pixels = u64::from(width)
+        .checked_mul(u64::from(height))
+        .ok_or_else(heif_too_large)?;
+    if file_len > MAX_HEIF_FILE_BYTES
+        || width == 0
+        || height == 0
+        || width > MAX_HEIF_EDGE
+        || height > MAX_HEIF_EDGE
+        || pixels > MAX_HEIF_PIXELS
+        || decoded_bytes > MAX_HEIF_DECODED_BYTES
+    {
+        return Err(heif_too_large());
+    }
+    Ok(())
+}
+
 /// Wrap a single uploaded image into a one-page PDF (so it can be previewed,
 /// merged and edited exactly like any PDF). JPEGs are embedded losslessly; other
 /// formats are decoded and re-encoded to JPEG. Returns the output PDF path.
 pub fn image_to_pdf(app: &tauri::AppHandle, input: &str) -> Result<String, AppError> {
-    use std::io::BufWriter;
-
     let in_path = Path::new(input);
     if !in_path.is_file() {
         return Err(AppError::new(
@@ -155,6 +234,13 @@ pub fn image_to_pdf(app: &tauri::AppHandle, input: &str) -> Result<String, AppEr
     }
 
     let dir = temp::root(app)?.join("images").join(hash_hex(input));
+    let out_pdf = image_to_pdf_in_dir(in_path, &dir)?;
+    Ok(out_pdf.to_string_lossy().to_string())
+}
+
+fn image_to_pdf_in_dir(in_path: &Path, dir: &Path) -> Result<PathBuf, AppError> {
+    use std::io::BufWriter;
+
     std::fs::create_dir_all(&dir)
         .map_err(|e| AppError::io("Could not create a temp directory.", e))?;
 
@@ -184,7 +270,8 @@ pub fn image_to_pdf(app: &tauri::AppHandle, input: &str) -> Result<String, AppEr
                     .with_suggestion("Supported: HEIC, HEIF, PNG, JPEG, GIF, BMP, WebP, TIFF.")
             })?
         };
-        let rgb = img.to_rgb8();
+        // Consume an already-RGB8 decode instead of cloning its full pixel buffer.
+        let rgb = img.into_rgb8();
         let (w, h) = (rgb.width(), rgb.height());
         let file = std::fs::File::create(&jpg_path)
             .map_err(|e| AppError::io("Could not write the converted image.", e))?;
@@ -214,17 +301,73 @@ pub fn image_to_pdf(app: &tauri::AppHandle, input: &str) -> Result<String, AppEr
         dpi: 96,
     }];
     write_image_pdf(&out_pdf_str, &pages)?;
-    Ok(out_pdf_str)
+    Ok(out_pdf)
 }
 
 /// Decode the primary image in a HEIC/HEIF container with the bundled libheif.
 fn decode_heif(path: &Path) -> Result<image::DynamicImage, AppError> {
-    let bytes = std::fs::read(path)
+    use image::ImageDecoder;
+
+    let file = std::fs::File::open(path)
         .map_err(|e| AppError::io("Could not read the HEIC/HEIF image.", e))?;
-    heif::decode(&bytes).map_err(|e| {
-        AppError::new("INVALID_IMAGE", "Could not decode this HEIC/HEIF image", e.to_string())
+    let metadata = file
+        .metadata()
+        .map_err(|e| AppError::io("Could not inspect the HEIC/HEIF image.", e))?;
+    if !metadata.file_type().is_file() {
+        return Err(AppError::new(
+            "INVALID_IMAGE",
+            "Could not decode this HEIC/HEIF image",
+            "The selected path is not a regular image file.",
+        ));
+    }
+    if metadata.len() > MAX_HEIF_FILE_BYTES {
+        return Err(heif_too_large());
+    }
+
+    let exceeded = Arc::new(AtomicBool::new(false));
+    let reader = BoundedReader::new(file, MAX_HEIF_FILE_BYTES, exceeded.clone());
+    let decoder = heif::HeifDecoder::new(reader).map_err(|error| {
+        if exceeded.load(Ordering::Relaxed) {
+            heif_too_large()
+        } else {
+            AppError::new(
+                "INVALID_IMAGE",
+                "Could not decode this HEIC/HEIF image",
+                error.to_string(),
+            )
             .with_suggestion("Try exporting the original photo again if the file is incomplete.")
-    })
+        }
+    })?;
+
+    // Inspect the decoded layout before libheif allocates any pixel planes.
+    let (width, height) = decoder.dimensions();
+    let color = decoder.color_type();
+    let decoded_bytes = decoder.total_bytes();
+    let expected_bytes = u64::from(width)
+        .saturating_mul(u64::from(height))
+        .saturating_mul(u64::from(color.bytes_per_pixel()));
+    if decoded_bytes != expected_bytes {
+        return Err(AppError::new(
+            "INVALID_IMAGE",
+            "Could not decode this HEIC/HEIF image",
+            "The image reported an inconsistent decoded size.",
+        ));
+    }
+    validate_heif_limits(metadata.len(), width, height, decoded_bytes)?;
+
+    let image = image::DynamicImage::from_decoder(decoder.with_threads(1)).map_err(|error| {
+        AppError::new(
+            "INVALID_IMAGE",
+            "Could not decode this HEIC/HEIF image",
+            error.to_string(),
+        )
+        .with_suggestion("Try exporting the original photo again if the file is incomplete.")
+    })?;
+    let image_bytes = u64::from(image.width())
+        .saturating_mul(u64::from(image.height()))
+        .saturating_mul(u64::from(image.color().bytes_per_pixel()));
+    validate_heif_limits(metadata.len(), image.width(), image.height(), image_bytes)?;
+    Ok(image)
 }
 
 /// Render one page to a JPEG at the given DPI/quality. `idx` keeps file names
@@ -489,4 +632,120 @@ fn write_image_pdf(output: &str, pages: &[PageImage]) -> Result<(), AppError> {
     std::fs::write(output, &buf)
         .map_err(|e| AppError::output_not_writable(&format!("{output} ({e})")))?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn unique_tmp(prefix: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "{prefix}-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    fn sample_heif() -> Vec<u8> {
+        let image = image::DynamicImage::ImageRgb8(image::RgbImage::from_fn(64, 64, |x, y| {
+            image::Rgb([(x * 3) as u8, (y * 3) as u8, ((x + y) * 2) as u8])
+        }));
+        heif::encode(&image).expect("encode HEIC fixture")
+    }
+
+    #[test]
+    fn heif_limits_accept_normal_photos_and_reject_oversize_headers() {
+        assert!(validate_heif_limits(8 * 1024 * 1024, 6_000, 4_000, 72_000_000).is_ok());
+
+        for result in [
+            validate_heif_limits(MAX_HEIF_FILE_BYTES + 1, 10, 10, 300),
+            validate_heif_limits(100, MAX_HEIF_EDGE + 1, 10, 300),
+            validate_heif_limits(100, 8_000, 4_001, 300),
+            validate_heif_limits(100, 0, 10, 0),
+        ] {
+            assert_eq!(result.unwrap_err().code, "IMAGE_TOO_LARGE");
+        }
+    }
+
+    #[test]
+    fn heif_limits_include_high_depth_and_alpha_decode_buffers() {
+        let twelve_megapixels = 12_000_000;
+        // libheif exposes 10/12-bit samples as 16-bit RGB(A).
+        assert!(validate_heif_limits(10_000_000, 4_000, 3_000, twelve_megapixels * 6).is_ok());
+        assert!(validate_heif_limits(10_000_000, 4_000, 3_000, twelve_megapixels * 8).is_ok());
+
+        for decoded_bytes in [32_000_000 * 6, 32_000_000 * 8, MAX_HEIF_DECODED_BYTES + 1] {
+            assert_eq!(
+                validate_heif_limits(10_000_000, 8_000, 4_000, decoded_bytes)
+                    .unwrap_err()
+                    .code,
+                "IMAGE_TOO_LARGE"
+            );
+        }
+    }
+
+    #[test]
+    fn bounded_reader_detects_growth_past_its_limit() {
+        let exceeded = Arc::new(AtomicBool::new(false));
+        let source = std::io::Cursor::new(vec![0u8; 9]);
+        let mut reader = BoundedReader::new(source, 8, exceeded.clone());
+        let mut output = Vec::new();
+
+        assert!(reader.read_to_end(&mut output).is_err());
+        assert_eq!(output.len(), 8);
+        assert!(exceeded.load(Ordering::Relaxed));
+    }
+
+    #[test]
+    fn decode_heif_rejects_invalid_and_truncated_files_without_panicking() {
+        let dir = unique_tmp("offpdf-heif-invalid");
+
+        let invalid = dir.join("invalid.heic");
+        std::fs::write(&invalid, b"not a HEIC container").unwrap();
+        assert_eq!(decode_heif(&invalid).unwrap_err().code, "INVALID_IMAGE");
+
+        let mut truncated_bytes = sample_heif();
+        truncated_bytes.truncate(truncated_bytes.len() / 2);
+        let truncated = dir.join("truncated.heif");
+        std::fs::write(&truncated, truncated_bytes).unwrap();
+        assert_eq!(decode_heif(&truncated).unwrap_err().code, "INVALID_IMAGE");
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn decode_heif_rejects_oversize_file_before_reading_it() {
+        let dir = unique_tmp("offpdf-heif-large");
+        let path = dir.join("large.heic");
+        let file = std::fs::File::create(&path).unwrap();
+        file.set_len(MAX_HEIF_FILE_BYTES + 1).unwrap();
+        drop(file);
+
+        assert_eq!(decode_heif(&path).unwrap_err().code, "IMAGE_TOO_LARGE");
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn heic_and_heif_complete_the_jpeg_and_pdf_pipeline() {
+        let dir = unique_tmp("offpdf-heif-pdf");
+        let bytes = sample_heif();
+
+        for ext in ["heic", "heif"] {
+            let input = dir.join(format!("photo.{ext}"));
+            let work = dir.join(format!("work-{ext}"));
+            std::fs::write(&input, &bytes).unwrap();
+
+            let output = image_to_pdf_in_dir(&input, &work).expect("convert HEIF image to PDF");
+            let document = lopdf::Document::load(&output).expect("load generated PDF");
+            assert_eq!(document.get_pages().len(), 1);
+            assert!(work.join("page.jpg").is_file());
+        }
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
 }

--- a/src/lib/tools.ts
+++ b/src/lib/tools.ts
@@ -139,9 +139,9 @@ export const TOOLS: ToolMeta[] = [
   {
     id: "pdfToOffice",
     name: "PDF to Office",
-    description: "Convert a PDF to editable Word, PowerPoint or Excel.",
+    description: "Convert a PDF to editable Word or PowerPoint.",
     longDescription:
-      "Convert the combined document to an editable Office file (Word, PowerPoint or Excel) using LibreOffice. Best effort — complex layouts may not be reproduced exactly.",
+      "Convert the combined document to an editable Office file (Word or PowerPoint) using LibreOffice. Best effort — complex layouts may not be reproduced exactly.",
     icon: "fileText",
     path: "/tools/pdf-to-office",
     category: "Convert",

--- a/src/state/workspaceStore.test.ts
+++ b/src/state/workspaceStore.test.ts
@@ -1,0 +1,116 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const commands = vi.hoisted(() => ({
+  getFileInfo: vi.fn(),
+  imageToPdf: vi.fn(),
+  officeToPdf: vi.fn(),
+}));
+
+vi.mock("@/lib/tauriCommands", () => commands);
+
+import { useWorkspace } from "./workspaceStore";
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  useWorkspace.setState({ files: [], activeIndex: 0, loading: false });
+  commands.getFileInfo.mockImplementation(async (path: string) => ({
+    path,
+    name: path.split(/[\\/]/).pop() || path,
+    sizeBytes: 100,
+    pageCount: 1,
+    isValidPdf: true,
+  }));
+  commands.officeToPdf.mockImplementation(async (path: string) => `${path}.pdf`);
+});
+
+describe("workspace image imports", () => {
+  it("serializes conversions and reuses a conversion for duplicate image paths", async () => {
+    let active = 0;
+    let maxActive = 0;
+    commands.imageToPdf.mockImplementation(async (path: string) => {
+      active += 1;
+      maxActive = Math.max(maxActive, active);
+      await Promise.resolve();
+      active -= 1;
+      return `${path}.pdf`;
+    });
+
+    const result = await useWorkspace
+      .getState()
+      .addPaths(["/photos/a.heic", "/photos/b.heif", "/photos/a.heic"]);
+
+    expect(maxActive).toBe(1);
+    expect(commands.imageToPdf).toHaveBeenCalledTimes(2);
+    expect(commands.imageToPdf).toHaveBeenNthCalledWith(1, "/photos/a.heic");
+    expect(commands.imageToPdf).toHaveBeenNthCalledWith(2, "/photos/b.heif");
+    expect(result.added).toBe(3);
+    expect(result.errors).toEqual([]);
+    expect(useWorkspace.getState().files).toHaveLength(3);
+  });
+
+  it("serializes image conversions across concurrent addPaths calls", async () => {
+    let active = 0;
+    let maxActive = 0;
+    let resolveFirst!: () => void;
+    let resolveSecond!: () => void;
+    commands.imageToPdf
+      .mockImplementationOnce(
+        (path: string) =>
+          new Promise<string>((resolve) => {
+            active += 1;
+            maxActive = Math.max(maxActive, active);
+            resolveFirst = () => {
+              active -= 1;
+              resolve(`${path}.pdf`);
+            };
+          }),
+      )
+      .mockImplementationOnce(
+        (path: string) =>
+          new Promise<string>((resolve) => {
+            active += 1;
+            maxActive = Math.max(maxActive, active);
+            resolveSecond = () => {
+              active -= 1;
+              resolve(`${path}.pdf`);
+            };
+          }),
+      );
+
+    const firstPromise = useWorkspace.getState().addPaths(["/photos/first.heic"]);
+    const secondPromise = useWorkspace.getState().addPaths(["/photos/second.heif"]);
+    await Promise.resolve();
+
+    expect(useWorkspace.getState().loading).toBe(true);
+    expect(commands.imageToPdf).toHaveBeenCalledTimes(1);
+    resolveFirst();
+    const first = await firstPromise;
+
+    expect(useWorkspace.getState().loading).toBe(true);
+    expect(commands.imageToPdf).toHaveBeenCalledTimes(2);
+    resolveSecond();
+    const second = await secondPromise;
+
+    expect(maxActive).toBe(1);
+    expect(commands.imageToPdf).toHaveBeenCalledTimes(2);
+    expect(first.added).toBe(1);
+    expect(second.added).toBe(1);
+    expect(useWorkspace.getState().files).toHaveLength(2);
+    expect(useWorkspace.getState().loading).toBe(false);
+  });
+
+  it("keeps importing after one image conversion returns an error", async () => {
+    commands.imageToPdf
+      .mockRejectedValueOnce(new Error("The image is incomplete."))
+      .mockResolvedValueOnce("/tmp/good.pdf");
+
+    const result = await useWorkspace
+      .getState()
+      .addPaths(["/photos/bad.heic", "/photos/good.heif"]);
+
+    expect(result.added).toBe(1);
+    expect(result.errors).toEqual(["bad.heic: The image is incomplete."]);
+    expect(useWorkspace.getState().files).toHaveLength(1);
+    expect(useWorkspace.getState().loading).toBe(false);
+  });
+});

--- a/src/state/workspaceStore.ts
+++ b/src/state/workspaceStore.ts
@@ -13,6 +13,17 @@ import { isImagePath, isOfficePath, SUPPORTED_RE } from "@/lib/fileTypes";
 import { toAppError, type FileInfo, type WorkspaceFile } from "@/lib/types";
 
 let uidSeq = 0;
+let imageConversionQueue: Promise<void> = Promise.resolve();
+let activeAddOperations = 0;
+
+function imageToPdfSerial(path: string): Promise<string> {
+  const conversion = imageConversionQueue.then(() => imageToPdf(path));
+  imageConversionQueue = conversion.then(
+    () => undefined,
+    () => undefined,
+  );
+  return conversion;
+}
 
 export interface AddResult {
   added: number;
@@ -52,27 +63,38 @@ export const useWorkspace = create<WorkspaceState>((set, get) => ({
     const notPdf = supported.length < paths.length;
     if (supported.length === 0) return { added: 0, invalid: [], notPdf, errors: [] };
 
+    activeAddOperations += 1;
     set({ loading: true });
     const errors: string[] = [];
     try {
       const existing = new Set(get().files.map((f) => f.path));
-      const infos = await Promise.all(
-        supported.map(async (p) => {
-          try {
-            if (isImagePath(p)) {
-              return await getFileInfo(await imageToPdf(p));
+      const convertedImages = new Map<string, string>();
+      const infos: Array<FileInfo | null> = [];
+
+      // Image decoders can use hundreds of megabytes for a single large photo.
+      // Keep conversions serial, and convert duplicate image paths only once
+      // while still allowing the resulting PDF to be added more than once.
+      for (const p of supported) {
+        try {
+          if (isImagePath(p)) {
+            let pdfPath = convertedImages.get(p);
+            if (!pdfPath) {
+              pdfPath = await imageToPdfSerial(p);
+              convertedImages.set(p, pdfPath);
             }
-            if (isOfficePath(p)) {
-              return await getFileInfo(await officeToPdf(p));
-            }
-            if (existing.has(p)) return null; // already loaded
-            return await getFileInfo(p);
-          } catch (e) {
-            errors.push(`${baseName(p)}: ${toAppError(e).message}`);
-            return null;
+            infos.push(await getFileInfo(pdfPath));
+          } else if (isOfficePath(p)) {
+            infos.push(await getFileInfo(await officeToPdf(p)));
+          } else if (existing.has(p)) {
+            infos.push(null); // already loaded
+          } else {
+            infos.push(await getFileInfo(p));
           }
-        }),
-      );
+        } catch (e) {
+          errors.push(`${baseName(p)}: ${toAppError(e).message}`);
+          infos.push(null);
+        }
+      }
       const valid = infos.filter((i): i is FileInfo => !!i && i.isValidPdf);
       const invalid = infos
         .filter((i): i is FileInfo => !!i && !i.isValidPdf)
@@ -86,13 +108,14 @@ export const useWorkspace = create<WorkspaceState>((set, get) => ({
         return {
           files,
           activeIndex: wasEmpty && files.length > 0 ? 0 : state.activeIndex,
-          loading: false,
         };
       });
       return { added: valid.length, invalid, notPdf, errors };
     } catch {
-      set({ loading: false });
       return { added: 0, invalid: [], notPdf, errors };
+    } finally {
+      activeAddOperations -= 1;
+      if (activeAddOperations === 0) set({ loading: false });
     }
   },
 


### PR DESCRIPTION
## Summary

- Bound HEIC/HEIF compressed and decoded memory before native pixel allocation
- Use one single-threaded decoder and serialize image imports across concurrent workspace additions
- Add recoverable invalid, truncated, oversized, batch, and full HEIC/HEIF-to-PDF regression coverage
- Prevent the unsigned Windows validation build from attaching files to GitHub Releases
- Build and verify the signed macOS DMG before attaching it to a matching draft/tag
- Add the Windows code-signing policy and correct stale PDF-to-Office/roadmap copy

## Verification

- [x] `npm test` — 149 tests
- [x] `npm run build`
- [x] `cargo check --manifest-path src-tauri/Cargo.toml`
- [x] `cargo test --manifest-path src-tauri/Cargo.toml --lib` — 96 tests
- [x] `actionlint .github/workflows/*.yml`
- [x] `git diff --check`

Addresses #14. The issue remains open until hosted Windows/macOS verification and a real-device HEIC smoke test are complete.