### PR TITLE
fix: avoid “0 min ago” for recent timestamps

### DIFF
--- a/src/lib/formatBytes.test.ts
+++ b/src/lib/formatBytes.test.ts
@@ -77,6 +77,11 @@ describe("formatRelativeTime", () => {
     expect(formatRelativeTime(now - 44_000, now)).toBe("just now");
   });
 
+  it("returns '1 min ago' for times from 45 through 59 seconds ago", () => {
+    expect(formatRelativeTime(now - 45_000, now)).toBe("1 min ago");
+    expect(formatRelativeTime(now - 59_000, now)).toBe("1 min ago");
+  });
+
   it("returns 'X min ago' for times less than 60 minutes ago", () => {
     expect(formatRelativeTime(now - 60_000, now)).toBe("1 min ago");
     expect(formatRelativeTime(now - 5 * 60_000, now)).toBe("5 min ago");

--- a/src/lib/formatBytes.ts
+++ b/src/lib/formatBytes.ts
@@ -39,7 +39,7 @@ export function formatRelativeTime(epochMs: number, now = Date.now()): string {
   const diff = Math.max(0, now - epochMs);
   const sec = Math.floor(diff / 1000);
   if (sec < 45) return "just now";
-  const min = Math.floor(sec / 60);
+  const min = Math.max(1, Math.floor(sec / 60));
   if (min < 60) return `${min} min ago`;
   const hr = Math.floor(min / 60);
   if (hr < 24) return `${hr} hour${hr === 1 ? "" : "s"} ago`;


### PR DESCRIPTION
## Summary
- clamp the minute count to at least 1 once timestamps leave the 45-second `just now` window
- add deterministic boundary coverage for 45 and 59 seconds

## Testing
- `npm test -- src/lib/formatBytes.test.ts`
- `npm run typecheck`

Closes #21