### PR TITLE
docs: make the GitHub star action easier to find

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 <p align="center">
   <strong><a href="#downloads">View downloads</a></strong>
   · <a href="https://offpdf.com">Visit offpdf.com</a>
+  · <a href="https://github.com/McanKul/offpdf">Star OffPDF on GitHub</a>
   · <a href="./CONTRIBUTING.md">Contribute</a>
 </p>
 


### PR DESCRIPTION
## Summary

Adds a small, non-intrusive GitHub star link to the README storefront alongside downloads, the website, and contribution links.

This keeps the existing product and Windows distribution messaging unchanged.

## Checks

- [x] README-only change
- [x] `git diff --check`
