### PR TITLE
release: publish Windows installer through GitHub Releases

### DIFF
--- a/.github/release-notes/v0.3.0.md
+++ b/.github/release-notes/v0.3.0.md
@@ -17,7 +17,12 @@ contributing to this release.
 Packages:
 
 - Signed and notarized DMG for Apple Silicon Macs
-- Windows is withheld until the Authenticode signing workflow is ready
+- Windows x64 NSIS installer — unsigned while Authenticode signing is pending.
+  The package passes build, install, startup, runtime, and Microsoft Defender
+  checks before it is attached to this release. Windows may show an Unknown
+  Publisher or SmartScreen warning; verify the accompanying SHA-256 file before
+  use. This Windows package is available only from GitHub Releases and is not
+  linked from offpdf.com.
 
 See [CHANGELOG.md](https://github.com/McanKul/offpdf/blob/v0.3.0/CHANGELOG.md)
 for full details.

--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -7,7 +7,7 @@ permissions:
   contents: write
 
 concurrency:
-  group: macos-release-${{ github.ref }}
+  group: desktop-release-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:
@@ -124,31 +124,43 @@ jobs:
           test -f "$notes_path"
           test -n "$dmg_path"
 
+          release_exists=false
           if gh release view "$tag" --json isDraft >/dev/null 2>&1; then
+            release_exists=true
+          fi
+
+          if [[ "$release_exists" == "false" ]]; then
+            if ! gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${tag}" >/dev/null 2>&1; then
+              gh api --method POST "repos/${GITHUB_REPOSITORY}/git/refs" \
+                -f "ref=refs/tags/${tag}" \
+                -f "sha=${GITHUB_SHA}" >/dev/null
+            fi
+          fi
+
+          tag_sha="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${tag}" --jq '.sha')"
+          if [[ "$tag_sha" != "$GITHUB_SHA" ]]; then
+            echo "Refusing to attach a build from $GITHUB_SHA to $tag at $tag_sha." >&2
+            exit 1
+          fi
+
+          if [[ "$release_exists" == "true" ]]; then
             is_draft="$(gh release view "$tag" --json isDraft --jq '.isDraft')"
             if [[ "$is_draft" != "true" ]]; then
-              echo "Refusing to replace assets on published release $tag." >&2
+              echo "Refusing to modify published release $tag." >&2
               exit 1
             fi
-            tag_sha="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${tag}" --jq '.sha')"
-            if [[ "$tag_sha" != "$GITHUB_SHA" ]]; then
-              echo "Refusing to attach a build from $GITHUB_SHA to $tag at $tag_sha." >&2
-              exit 1
-            fi
-            gh release upload "$tag" "$dmg_path" --clobber
-            gh release edit "$tag" \
-              --title "OffPDF ${tag}" \
-              --notes-file "$notes_path"
           else
-            if tag_sha="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${tag}" --jq '.sha' 2>/dev/null)"; then
-              if [[ "$tag_sha" != "$GITHUB_SHA" ]]; then
-                echo "Refusing to create a release for $tag at $tag_sha from $GITHUB_SHA." >&2
-                exit 1
-              fi
-            fi
-            gh release create "$tag" "$dmg_path" \
+            gh release create "$tag" \
+              --verify-tag \
               --draft \
-              --target "$GITHUB_SHA" \
               --title "OffPDF ${tag}" \
               --notes-file "$notes_path"
           fi
+
+          dmg_name="$(basename "$dmg_path")"
+          if gh release view "$tag" --json assets --jq '.assets[].name' | grep -Fqx "$dmg_name"; then
+            echo "Refusing to replace existing release asset $dmg_name." >&2
+            exit 1
+          fi
+
+          gh release upload "$tag" "$dmg_path"

--- a/.github/workflows/windows-release.yml
+++ b/.github/workflows/windows-release.yml
@@ -1,4 +1,4 @@
-name: Windows Build Verification
+name: Windows x64 Release
 
 on:
   workflow_dispatch:
@@ -21,16 +21,16 @@ on:
         type: string
 
 permissions:
-  contents: read
+  contents: write
 
 concurrency:
-  group: windows-release-${{ github.ref }}
+  group: desktop-release-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:
   windows-x64:
-    name: Build and smoke-test Windows installer (not published)
-    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/development'
+    name: Build, verify, and stage Windows x64 installer
+    if: github.ref == 'refs/heads/main'
     runs-on: windows-latest
     timeout-minutes: 120
 
@@ -72,16 +72,26 @@ jobs:
         shell: pwsh
         run: ./scripts/prepare-libreoffice-windows.ps1 -Version "${{ github.event.inputs.libreoffice_version }}"
 
-      - name: Build Windows installer for smoke testing
+      - name: Build Windows installer
         uses: tauri-apps/tauri-action@v0
         with:
           args: --bundles nsis
 
-      - name: Enforce Windows signing gate
+      - name: Verify unsigned Authenticode state
         shell: pwsh
         run: |
-          Write-Host 'This workflow validates the Windows bundle locally only.'
-          Write-Host 'Do not publish it until the Authenticode signing workflow is enabled.'
+          $installer = @(Get-ChildItem -Path src-tauri/target/release/bundle/nsis -Filter '*-setup.exe')
+          if ($installer.Count -ne 1) { throw "Expected one NSIS installer, found $($installer.Count)." }
+
+          $appPath = 'src-tauri/target/release/offpdf.exe'
+          if (-not (Test-Path $appPath)) { throw "Built application not found at $appPath" }
+
+          foreach ($file in @($installer[0].FullName, $appPath)) {
+            $signature = Get-AuthenticodeSignature -FilePath $file
+            if ($signature.Status -ne 'NotSigned') {
+              throw "Expected an unsigned build, but ${file} has Authenticode status $($signature.Status)."
+            }
+          }
 
       - name: Smoke test installed application
         shell: pwsh
@@ -108,6 +118,88 @@ jobs:
           Start-Sleep -Seconds 10
           if ($app.HasExited) { throw "OffPDF exited during startup with code $($app.ExitCode)." }
           Stop-Process -Id $app.Id -Force
+
+      - name: Scan installer with Microsoft Defender
+        shell: pwsh
+        run: |
+          $installer = @(Get-ChildItem -Path src-tauri/target/release/bundle/nsis -Filter '*-setup.exe')
+          if ($installer.Count -ne 1) { throw "Expected one NSIS installer, found $($installer.Count)." }
+
+          $defender = Join-Path $env:ProgramFiles 'Windows Defender\MpCmdRun.exe'
+          if (-not (Test-Path $defender)) {
+            $defender = Get-ChildItem "$env:ProgramData\Microsoft\Windows Defender\Platform" -Filter MpCmdRun.exe -Recurse |
+              Sort-Object FullName -Descending |
+              Select-Object -First 1 -ExpandProperty FullName
+          }
+          if (-not $defender) { throw 'Microsoft Defender command-line scanner was not found.' }
+
+          & $defender -Scan -ScanType 3 -File $installer[0].FullName -DisableRemediation
+          if ($LASTEXITCODE -ne 0) { throw "Microsoft Defender scan failed with exit code $LASTEXITCODE." }
+
+      - name: Attach verified installer to draft release
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          $version = node -p "require('./package.json').version"
+          $tag = "v$version"
+          $notesPath = ".github/release-notes/$tag.md"
+          if (-not (Test-Path $notesPath)) { throw "Release notes not found at $notesPath" }
+
+          $installer = @(Get-ChildItem -Path src-tauri/target/release/bundle/nsis -Filter '*-setup.exe')
+          if ($installer.Count -ne 1) { throw "Expected one NSIS installer, found $($installer.Count)." }
+
+          $expectedName = "OffPDF_${version}_x64-setup.exe"
+          if ($installer[0].Name -ne $expectedName) {
+            throw "Unexpected installer name $($installer[0].Name); expected $expectedName."
+          }
+
+          $checksumPath = "$($installer[0].FullName).sha256"
+          $hash = (Get-FileHash -Algorithm SHA256 $installer[0].FullName).Hash.ToLowerInvariant()
+          "$hash  $($installer[0].Name)" | Set-Content -Path $checksumPath -Encoding utf8NoBOM
+
+          $releaseExists = $true
+          gh release view $tag --json isDraft *> $null
+          if ($LASTEXITCODE -ne 0) { $releaseExists = $false }
+
+          if (-not $releaseExists) {
+            gh api "repos/$env:GITHUB_REPOSITORY/git/ref/tags/$tag" *> $null
+            if ($LASTEXITCODE -ne 0) {
+              gh api --method POST "repos/$env:GITHUB_REPOSITORY/git/refs" `
+                -f "ref=refs/tags/$tag" `
+                -f "sha=$env:GITHUB_SHA" *> $null
+              if ($LASTEXITCODE -ne 0) { throw "Could not create tag $tag." }
+            }
+          }
+
+          $tagSha = gh api "repos/$env:GITHUB_REPOSITORY/commits/$tag" --jq '.sha'
+          if ($LASTEXITCODE -ne 0 -or $tagSha -ne $env:GITHUB_SHA) {
+            throw "Refusing to attach $env:GITHUB_SHA to $tag at $tagSha."
+          }
+
+          if ($releaseExists) {
+            $isDraft = gh release view $tag --json isDraft --jq '.isDraft'
+            if ($isDraft -ne 'true') { throw "Refusing to modify published release $tag." }
+          } else {
+            gh release create $tag `
+              --verify-tag `
+              --draft `
+              --title "OffPDF $tag" `
+              --notes-file $notesPath
+            if ($LASTEXITCODE -ne 0) { throw "Could not create draft release $tag." }
+          }
+
+          $existingAssets = @(gh release view $tag --json assets --jq '.assets[].name')
+          foreach ($name in @($installer[0].Name, (Split-Path $checksumPath -Leaf))) {
+            if ($existingAssets -contains $name) {
+              throw "Refusing to replace existing release asset $name."
+            }
+          }
+
+          gh release upload $tag $installer[0].FullName $checksumPath
+          if ($LASTEXITCODE -ne 0) { throw "Could not upload Windows assets to $tag." }
+
+          "Staged unsigned Windows installer in draft release $tag." | Add-Content -Path $env:GITHUB_STEP_SUMMARY
 
       - name: List bundle outputs
         shell: pwsh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,8 @@ All notable project changes should be documented here.
 
 ### Distribution
 
-- New Windows packages are withheld until the Authenticode signing and verification workflow is ready. The manual Windows workflow now builds and smoke-tests locally without attaching an unsigned installer to a GitHub Release.
+- The Windows x64 installer is available through GitHub Releases with an accompanying SHA-256 file. It remains clearly marked as unsigned while Authenticode signing is completed and is not linked from offpdf.com.
+- The Windows release workflow builds, installs, launches, checks bundled runtimes, and scans the installer with Microsoft Defender before attaching it to a draft release.
 
 ## 0.2.2
 

--- a/CODE_SIGNING_POLICY.md
+++ b/CODE_SIGNING_POLICY.md
@@ -8,11 +8,13 @@ tag, build log, and resulting artifact must remain traceable to one another.
 
 - Apple Silicon macOS releases are signed with an Apple Developer ID certificate,
   notarized by Apple, and verified before publication.
-- Public Windows distribution is paused while the Authenticode signing workflow
-  is being prepared. An unsigned Windows validation build must not be attached to
-  a public GitHub Release or linked as an official download.
-- Windows publication will resume only after the application executable,
-  installer, and uninstaller pass Authenticode and timestamp verification.
+- Windows x64 installers may be published only through GitHub Releases while the
+  Authenticode workflow is being prepared. They must be clearly marked as
+  unsigned, include a SHA-256 file, and pass the documented build, install,
+  startup, runtime, and Microsoft Defender checks before attachment.
+- Unsigned Windows installers are not linked from offpdf.com. Once Authenticode
+  is enabled, the application executable, installer, and uninstaller must pass
+  signature and timestamp verification before the website links the package.
 
 ## Roles and approval
 
@@ -28,10 +30,13 @@ tag, build log, and resulting artifact must remain traceable to one another.
 
 1. Required frontend and Rust checks must pass on the release commit.
 2. Release builds run on GitHub-hosted runners from the tagged `main` commit.
-3. Each platform workflow completes its explicitly documented signature,
-   notarization, and smoke-test gates before it can attach a release artifact.
-4. The future Windows workflow must additionally verify the application,
-   installer, uninstaller, and RFC 3161 timestamp before publishing anything.
+3. Each platform workflow completes its documented verification and smoke-test
+   gates before it can attach a release artifact. macOS additionally requires a
+   valid signature and notarization ticket.
+4. The temporary unsigned Windows path verifies the unsigned state, produces a
+   SHA-256 file, installs and launches the app, checks bundled runtimes, and runs
+   Microsoft Defender. The future signed path must additionally verify the
+   application, installer, uninstaller, and RFC 3161 timestamp.
 5. A failed or unverifiable artifact is discarded rather than published.
 
 OffPDF has no automatic updater. Users choose when to download and install a

--- a/README.md
+++ b/README.md
@@ -61,13 +61,15 @@ service in the middle.
 
 | Platform | Package | Status |
 | --- | --- | --- |
-| Windows x64 | New package not currently published | v0.3 is withheld while Authenticode signing is prepared; older unsigned builds remain in release history |
+| Windows x64 | [Download from the latest release](https://github.com/McanKul/offpdf/releases/latest) | Available on GitHub Releases; currently unsigned while Authenticode signing is completed |
 | macOS 11+ · Apple Silicon | [Download from the latest release](https://github.com/McanKul/offpdf/releases/latest) | Signed and notarized |
 | Intel Mac / Linux | [Build from source](#development) | No published package yet |
 
 The Windows installer is large because it includes the local engines needed to
 keep its core workflows offline. The macOS build bundles qpdf, Poppler, and
 Tesseract; LibreOffice is optional and only needed for Office and PDF/A tools.
+Until Authenticode signing is complete, the Windows package is distributed only
+through GitHub Releases and is not linked from offpdf.com.
 
 All published binaries are available on the
 [Releases page](https://github.com/McanKul/offpdf/releases).

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,7 +6,7 @@ reliable local processing, clear packaging, and a contributor-friendly project.
 ## Current release
 
 - **v0.2.2** is the latest published release. Its historical Windows package is
-  unsigned; new Windows distribution is paused rather than repeating that model.
+  unsigned and remains available through GitHub Releases.
 - The Apple Silicon macOS build is signed and notarized. It bundles qpdf,
   Poppler, and Tesseract; LibreOffice remains optional for Office and PDF/A work.
 
@@ -15,8 +15,9 @@ reliable local processing, clear packaging, and a contributor-friendly project.
 - **v0.3.0** is being prepared for distribution through GitHub Releases and
   [offpdf.com](https://offpdf.com).
 - The Windows x64 installer bundles qpdf, Poppler, Tesseract, and LibreOffice so
-  the supported workflows run offline. Public Windows distribution is paused
-  until the Authenticode signing workflow is ready.
+  the supported workflows run offline. It is distributed through GitHub Releases
+  with an explicit unsigned warning while Authenticode signing is completed;
+  offpdf.com does not link to it yet.
 - The app currently includes 23 tools for organizing, converting, optimizing,
   securing, and repairing PDFs.
 
@@ -38,7 +39,8 @@ reliable local processing, clear packaging, and a contributor-friendly project.
 
 ## Known limitations
 
-- A current Windows installer is not published while code signing is being set up.
+- Windows installers are currently unsigned and available only through GitHub
+  Releases; offpdf.com will link them after code signing is complete.
 - There are no official Intel Mac or Linux packages yet.
 - Office conversion and PDF/A require LibreOffice; it is not bundled on macOS.
 - Lossy compression rasterizes pages. Use text-preserving compression when text


### PR DESCRIPTION
## Summary

- publishes the Windows x64 NSIS installer through GitHub Releases while Authenticode signing is pending
- keeps the Windows package unlinked from offpdf.com
- builds, installs, launches, checks required runtimes, and scans the installer with Microsoft Defender before staging
- generates an accompanying SHA-256 file
- shares one release concurrency gate with macOS and refuses tag/SHA mismatches, published-release changes, or asset replacement
- updates GitHub-facing release documentation to state the unsigned Windows policy clearly

## Release flow

Both desktop workflows attach verified assets to the same `v0.3.0` draft from the exact `main` commit. The draft remains manual to publish. Windows is clearly labelled unsigned until Authenticode signing is complete.

## Verification

- [x] `actionlint`
- [x] YAML parse
- [x] PowerShell AST parse
- [x] macOS release shell `bash -n`
- [x] `git diff --check`
- [x] `npm test` (154 tests)
- [x] `npm run build`

No offpdf.com files are changed.