### PR TITLE
fix(ci): build frontend before macOS Rust smoke test

### DIFF
--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -39,6 +39,9 @@ jobs:
       - name: Install frontend dependencies
         run: npm ci
 
+      - name: Build frontend assets for Rust tests
+        run: npm run build
+
       - name: Smoke test HEIC and HEIF conversion
         run: cargo test --manifest-path src-tauri/Cargo.toml --lib heic_and_heif_complete_the_jpeg_and_pdf_pipeline
 


### PR DESCRIPTION
## Summary

Build the frontend before running the macOS HEIC/HEIF Rust smoke test. Tauri's compile-time context requires the configured `../dist` directory, so the previous release run stopped before the test itself ran.

## Verification

- `actionlint .github/workflows/macos-release.yml`
- `npm run build`
- `cargo test --manifest-path src-tauri/Cargo.toml --lib heic_and_heif_complete_the_jpeg_and_pdf_pipeline`
- `git diff --check`