### PR TITLE
feat(edit): add, edit and remove PDF link annotations (#35)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable project changes should be documented here.
 ### Added
 
 - Edit PDF: staged output is checked with `qpdf --check` and reopened for page boxes, per-page content identity, and catalog data before the destination file is replaced. A failed check leaves the original and any existing destination untouched. `qpdf --check` warnings (exit 3) still publish and appear on the completed job update.
+- Edit PDF: add, edit, and remove URI (`https` / `http` / `mailto`) and in-document GoTo link annotations. Unsupported actions are left unchanged. The original file is never overwritten.
 
 ### Fixed
 

--- a/src-tauri/src/commands/pdf.rs
+++ b/src-tauri/src/commands/pdf.rs
@@ -6,7 +6,9 @@
 //! removed AFTER the worker joins.
 
 use crate::error::AppError;
-use crate::models::{JobRegistry, JobResult, JobUpdate, PageGroup, PagePick, RotateGroup, SplitMode};
+use crate::models::{
+    JobRegistry, JobResult, JobUpdate, PageGroup, PagePick, RotateGroup, SplitMode,
+};
 use tauri::Emitter;
 
 /// Helper: emit the final "completed" update and build the JobResult.
@@ -155,7 +157,15 @@ pub async fn watermark_pdf(
     let app2 = app.clone();
     let jid = job_id.clone();
     let res = tauri::async_runtime::spawn_blocking(move || {
-        crate::pdf_engine::overlay::add_watermark(&app2, &handle, &jid, &groups, &output_path, &text, opacity)
+        crate::pdf_engine::overlay::add_watermark(
+            &app2,
+            &handle,
+            &jid,
+            &groups,
+            &output_path,
+            &text,
+            opacity,
+        )
     })
     .await
     .map_err(|e| AppError::engine_failed(format!("worker join error: {e}")))?;
@@ -181,7 +191,17 @@ pub async fn crop_pdf(
     let app2 = app.clone();
     let jid = job_id.clone();
     let res = tauri::async_runtime::spawn_blocking(move || {
-        crate::pdf_engine::crop::crop(&app2, &handle, &jid, &groups, &output_path, left, top, right, bottom)
+        crate::pdf_engine::crop::crop(
+            &app2,
+            &handle,
+            &jid,
+            &groups,
+            &output_path,
+            left,
+            top,
+            right,
+            bottom,
+        )
     })
     .await
     .map_err(|e| AppError::engine_failed(format!("worker join error: {e}")))?;
@@ -198,12 +218,22 @@ pub async fn edit_pdf_overlays(
     output_path: String,
     groups: Vec<PageGroup>,
     document: crate::pdf_engine::edit_overlay::EditDocumentIn,
+    links_complete: Option<bool>,
 ) -> Result<JobResult, AppError> {
     let handle = registry.register(&job_id);
     let app2 = app.clone();
     let jid = job_id.clone();
+    let complete = links_complete.unwrap_or(true);
     let res = tauri::async_runtime::spawn_blocking(move || {
-        crate::pdf_engine::edit_overlay::edit_pdf_overlays(&app2, &handle, &jid, &groups, &output_path, &document)
+        crate::pdf_engine::edit_overlay::edit_pdf_overlays(
+            &app2,
+            &handle,
+            &jid,
+            &groups,
+            &output_path,
+            &document,
+            complete,
+        )
     })
     .await
     .map_err(|e| AppError::engine_failed(format!("worker join error: {e}")))?;
@@ -243,7 +273,18 @@ pub async fn stamp_pdf(
     let app2 = app.clone();
     let jid = job_id.clone();
     let res = tauri::async_runtime::spawn_blocking(move || {
-        crate::pdf_engine::stamp::stamp_text(&app2, &handle, &jid, &groups, &output_path, page, &anchor, &text, color, size_pct)
+        crate::pdf_engine::stamp::stamp_text(
+            &app2,
+            &handle,
+            &jid,
+            &groups,
+            &output_path,
+            page,
+            &anchor,
+            &text,
+            color,
+            size_pct,
+        )
     })
     .await
     .map_err(|e| AppError::engine_failed(format!("worker join error: {e}")))?;
@@ -270,7 +311,18 @@ pub async fn poster_pdf(
     let app2 = app.clone();
     let jid = job_id.clone();
     let res = tauri::async_runtime::spawn_blocking(move || {
-        crate::pdf_engine::poster::poster(&app2, &handle, &jid, &groups, &output_path, page, tile_w, tile_h, overlap, marks)
+        crate::pdf_engine::poster::poster(
+            &app2,
+            &handle,
+            &jid,
+            &groups,
+            &output_path,
+            page,
+            tile_w,
+            tile_h,
+            overlap,
+            marks,
+        )
     })
     .await
     .map_err(|e| AppError::engine_failed(format!("worker join error: {e}")))?;
@@ -295,7 +347,16 @@ pub async fn nup_pdf(
     let app2 = app.clone();
     let jid = job_id.clone();
     let res = tauri::async_runtime::spawn_blocking(move || {
-        crate::pdf_engine::nup::nup(&app2, &handle, &jid, &groups, &output_path, &mode, sheet_w, sheet_h)
+        crate::pdf_engine::nup::nup(
+            &app2,
+            &handle,
+            &jid,
+            &groups,
+            &output_path,
+            &mode,
+            sheet_w,
+            sheet_h,
+        )
     })
     .await
     .map_err(|e| AppError::engine_failed(format!("worker join error: {e}")))?;
@@ -333,7 +394,14 @@ pub async fn add_page_numbers(
             None
         };
         crate::pdf_engine::overlay::add_page_numbers_formatted(
-            &app2, &handle, &jid, &groups, &output_path, &position, start, format,
+            &app2,
+            &handle,
+            &jid,
+            &groups,
+            &output_path,
+            &position,
+            start,
+            format,
         )
     })
     .await
@@ -357,7 +425,15 @@ pub async fn protect_pdf(
     let app2 = app.clone();
     let jid = job_id.clone();
     let res = tauri::async_runtime::spawn_blocking(move || {
-        crate::pdf_engine::protect(&app2, &handle, &jid, &groups, &user_password, &owner_password, &output_path)
+        crate::pdf_engine::protect(
+            &app2,
+            &handle,
+            &jid,
+            &groups,
+            &user_password,
+            &owner_password,
+            &output_path,
+        )
     })
     .await
     .map_err(|e| AppError::engine_failed(format!("worker join error: {e}")))?;
@@ -424,7 +500,15 @@ pub async fn rotate_pages(
     let app2 = app.clone();
     let jid = job_id.clone();
     let res = tauri::async_runtime::spawn_blocking(move || {
-        crate::pdf_engine::rotate(&app2, &handle, &jid, &groups, angle, &rotate_pages, &output_path)
+        crate::pdf_engine::rotate(
+            &app2,
+            &handle,
+            &jid,
+            &groups,
+            angle,
+            &rotate_pages,
+            &output_path,
+        )
     })
     .await
     .map_err(|e| AppError::engine_failed(format!("worker join error: {e}")))?;
@@ -471,7 +555,14 @@ pub async fn compress_pdf(
     let jid = job_id.clone();
     let res = tauri::async_runtime::spawn_blocking(move || {
         crate::pdf_engine::compress::compress(
-            &app2, &handle, &jid, &picks, &output_path, dpi, quality, target_bytes,
+            &app2,
+            &handle,
+            &jid,
+            &picks,
+            &output_path,
+            dpi,
+            quality,
+            target_bytes,
         )
     })
     .await

--- a/src-tauri/src/commands/pdf.rs
+++ b/src-tauri/src/commands/pdf.rs
@@ -218,12 +218,12 @@ pub async fn edit_pdf_overlays(
     output_path: String,
     groups: Vec<PageGroup>,
     document: crate::pdf_engine::edit_overlay::EditDocumentIn,
-    links_complete: Option<bool>,
+    incomplete_source_paths: Option<Vec<String>>,
 ) -> Result<JobResult, AppError> {
     let handle = registry.register(&job_id);
     let app2 = app.clone();
     let jid = job_id.clone();
-    let complete = links_complete.unwrap_or(true);
+    let incomplete = incomplete_source_paths.unwrap_or_default();
     let res = tauri::async_runtime::spawn_blocking(move || {
         crate::pdf_engine::edit_overlay::edit_pdf_overlays(
             &app2,
@@ -232,7 +232,7 @@ pub async fn edit_pdf_overlays(
             &groups,
             &output_path,
             &document,
-            complete,
+            &incomplete,
         )
     })
     .await

--- a/src-tauri/src/commands/render.rs
+++ b/src-tauri/src/commands/render.rs
@@ -122,6 +122,19 @@ pub async fn pdf_outline(input_path: String) -> Result<Vec<crate::models::Outlin
         .map_err(|e| AppError::io("Could not read the outline.", e))?
 }
 
+/// Supported URI / in-document GoTo `/Link` annots. Paths in, JSON out; never
+/// fetches a URI.
+#[tauri::command]
+pub async fn list_pdf_links(
+    input_path: String,
+) -> Result<Vec<crate::pdf_engine::edit_links::PdfLinkDto>, AppError> {
+    tauri::async_runtime::spawn_blocking(move || {
+        crate::pdf_engine::edit_links::list_pdf_links_cmd(&input_path)
+    })
+    .await
+    .map_err(|e| AppError::io("Could not read the links.", e))?
+}
+
 /// Visually compare two pages; returns a diff-overlay image + changed percent.
 #[tauri::command]
 pub async fn diff_pages(

--- a/src-tauri/src/commands/render.rs
+++ b/src-tauri/src/commands/render.rs
@@ -123,7 +123,8 @@ pub async fn pdf_outline(input_path: String) -> Result<Vec<crate::models::Outlin
 }
 
 /// Supported URI / in-document GoTo `/Link` annots. Paths in, JSON out; never
-/// fetches a URI.
+/// fetches a URI. Files over 400 MiB or with more than 5,000 supported links
+/// return an actionable error (not a silent empty or truncated list).
 #[tauri::command]
 pub async fn list_pdf_links(
     input_path: String,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -91,6 +91,7 @@ pub fn run() {
             commands::render::pdf_text,
             commands::render::page_pdf,
             commands::render::pdf_outline,
+            commands::render::list_pdf_links,
             commands::render::diff_pages,
             commands::render::office_available,
             commands::render::office_to_pdf,

--- a/src-tauri/src/pdf_engine/edit_links.rs
+++ b/src-tauri/src/pdf_engine/edit_links.rs
@@ -1,17 +1,17 @@
 //! PDF `/Link` annotations for Edit PDF (issue #35).
 //!
-//! Shared classifier + list/apply surface. Bodies are fail-today stubs so
-//! tests compile and fail on assertions until impl lands.
+//! Shared classifier + list/apply surface. Per-source dest ranges skip
+//! unlistable files so a mixed workspace can still rewrite complete sources.
 
 use crate::error::AppError;
 use lopdf::{Dictionary, Document, Object, ObjectId};
 use serde::Serialize;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::Path;
 
 /// Outline-sized load gate — same bound as [`super::outline`].
 const MAX_LINK_BYTES: u64 = 400 * 1024 * 1024;
-const MAX_LINKS: usize = 5000;
+pub(crate) const MAX_LINKS: usize = 5000;
 
 /// Classification of a link action (URI / in-document GoTo / leave-alone).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -151,67 +151,7 @@ pub fn list_link_annots(path: &Path) -> Result<Vec<ListedLink>, AppError> {
 /// Copy through every non-Link annot and every unsupported Link. Reject
 /// writing a non-allowlisted URI with an actionable [`AppError`].
 pub fn apply_link_annots(staged: &Path, links: &[SessionLink]) -> Result<(), AppError> {
-    for link in links {
-        if let LinkAction::Uri { uri } = &link.action {
-            if !uri_is_allowed(uri) {
-                return Err(unsafe_uri_error(uri));
-            }
-        }
-    }
-
-    let mut doc = Document::load(staged)
-        .map_err(|e| AppError::engine_failed(format!("Could not read the staged PDF: {e}")))?;
-    let pages = doc.get_pages();
-    let page_index_of = page_index_map(&doc);
-    let mut page_ids: Vec<(u32, ObjectId)> = pages.iter().map(|(&n, &id)| (n, id)).collect();
-    page_ids.sort_by_key(|(n, _)| *n);
-
-    let mut by_page: HashMap<u32, Vec<&SessionLink>> = HashMap::new();
-    for link in links {
-        if (link.page_index as usize) >= page_ids.len() {
-            return Err(AppError::new(
-                "BAD_EDIT",
-                "Link page is out of range",
-                format!(
-                    "A link points at page {}, but this PDF has {} page{}.",
-                    link.page_index + 1,
-                    page_ids.len(),
-                    if page_ids.len() == 1 { "" } else { "s" }
-                ),
-            )
-            .with_suggestion("Pick a page that exists in the document."));
-        }
-        by_page.entry(link.page_index).or_default().push(link);
-    }
-
-    for (num, page_id) in &page_ids {
-        let page_index = num.saturating_sub(1);
-        let existing = page_annot_objects(&doc, *page_id);
-        let mut kept: Vec<Object> = Vec::new();
-        let mut session: Vec<&SessionLink> = by_page.get(&page_index).cloned().unwrap_or_default();
-        for raw in existing {
-            if let Some(listed) = listed_from_annot(&doc, &raw, page_index, &page_index_of) {
-                if let Some(i) = session
-                    .iter()
-                    .position(|l| session_matches_listed(l, &listed))
-                {
-                    session.remove(i);
-                    kept.push(raw);
-                }
-                continue;
-            }
-            kept.push(raw);
-        }
-        for link in session {
-            let annot_id = add_session_link(&mut doc, link, &page_ids)?;
-            kept.push(annot_id.into());
-        }
-        set_page_annots(&mut doc, *page_id, kept)?;
-    }
-
-    doc.save(staged)
-        .map_err(|e| AppError::io("Could not write link annotations.", e))?;
-    Ok(())
+    apply_link_annots_impl(staged, links, None)
 }
 
 /// True when dest will still have any annot after apply (leftover ∪ added).
@@ -249,6 +189,118 @@ pub fn should_rewrite_supported_links(complete: bool, session_len: usize, dest_h
         return true;
     }
     dest_has
+}
+
+/// Dest 0-based page ranges Save should rewrite for this assemble.
+///
+/// Each complete source's dest pages. Incomplete sources are skipped so
+/// their assembled annots stay.
+pub fn dest_ranges_to_rewrite(
+    groups: &[(&str, u32)],
+    incomplete_paths: &[&str],
+) -> Vec<std::ops::Range<u32>> {
+    let mut start = 0u32;
+    let mut out = Vec::with_capacity(groups.len());
+    for &(path, n) in groups {
+        let end = start.saturating_add(n);
+        let incomplete = incomplete_paths.iter().any(|&p| p == path);
+        if !incomplete && n > 0 {
+            out.push(start..end);
+        }
+        start = end;
+    }
+    out
+}
+
+/// Apply session links, limited to `dest_pages` (0-based dest indexes).
+///
+/// An empty page list is a no-op. Pages not in `dest_pages` are left
+/// unchanged.
+pub fn apply_link_annots_for_pages(
+    staged: &Path,
+    links: &[SessionLink],
+    dest_pages: &[u32],
+) -> Result<(), AppError> {
+    if dest_pages.is_empty() {
+        return Ok(());
+    }
+    apply_link_annots_impl(staged, links, Some(dest_pages))
+}
+
+fn apply_link_annots_impl(
+    staged: &Path,
+    links: &[SessionLink],
+    dest_pages: Option<&[u32]>,
+) -> Result<(), AppError> {
+    for link in links {
+        if let LinkAction::Uri { uri } = &link.action {
+            if !uri_is_allowed(uri) {
+                return Err(unsafe_uri_error(uri));
+            }
+        }
+    }
+
+    let mut doc = Document::load(staged)
+        .map_err(|e| AppError::engine_failed(format!("Could not read the staged PDF: {e}")))?;
+    let pages = doc.get_pages();
+    let page_index_of = page_index_map(&doc);
+    let mut page_ids: Vec<(u32, ObjectId)> = pages.iter().map(|(&n, &id)| (n, id)).collect();
+    page_ids.sort_by_key(|(n, _)| *n);
+
+    let mut by_page: HashMap<u32, Vec<&SessionLink>> = HashMap::new();
+    for link in links {
+        if (link.page_index as usize) >= page_ids.len() {
+            return Err(AppError::new(
+                "BAD_EDIT",
+                "Link page is out of range",
+                format!(
+                    "A link points at page {}, but this PDF has {} page{}.",
+                    link.page_index + 1,
+                    page_ids.len(),
+                    if page_ids.len() == 1 { "" } else { "s" }
+                ),
+            )
+            .with_suggestion("Pick a page that exists in the document."));
+        }
+        by_page.entry(link.page_index).or_default().push(link);
+    }
+
+    let dest_filter: Option<HashSet<u32>> = dest_pages.map(|p| p.iter().copied().collect());
+
+    for (num, page_id) in &page_ids {
+        let page_index = num.saturating_sub(1);
+        if dest_filter
+            .as_ref()
+            .is_some_and(|set| !set.contains(&page_index))
+        {
+            continue;
+        }
+        let existing = page_annot_objects(&doc, *page_id);
+        let mut kept: Vec<Object> = Vec::new();
+        let mut session: Vec<&SessionLink> = by_page.get(&page_index).cloned().unwrap_or_default();
+        for raw in existing {
+            if let Some(listed) = listed_from_annot(&doc, &raw, page_index, &page_index_of) {
+                if let Some(i) = session
+                    .iter()
+                    .position(|l| session_matches_listed(l, &listed))
+                {
+                    session.remove(i);
+                    kept.push(raw);
+                }
+                continue;
+            }
+            kept.push(raw);
+        }
+        for link in session {
+            let annot_id = add_session_link(&mut doc, link, &page_ids)?;
+            kept.push(annot_id.into());
+        }
+        set_page_annots(&mut doc, *page_id, kept)?;
+    }
+
+    doc.save(staged)
+        .map_err(|e| AppError::io("Could not write link annotations.", e))?;
+    Ok(())
 }
 
 /// Command helper: size-gated list as JSON DTOs.
@@ -1566,5 +1618,90 @@ mod tests {
         std::fs::write(&path, b"not a pdf").unwrap();
         let err = list_link_annots(&path).expect_err("H4: load fail must be AppError, not Ok([])");
         assert_actionable(&err, "H4 load fail");
+    }
+
+    // --- H7 per-source rewrite ---------------------------------------------
+
+    fn page_uris(path: &Path, page_1based: u32) -> Vec<String> {
+        inspect_page_annots(path, page_1based)
+            .into_iter()
+            .filter(|a| a.subtype == "Link" && a.action_s.as_deref() == Some("URI"))
+            .filter_map(|a| a.uri)
+            .collect()
+    }
+
+    #[test]
+    fn incomplete_a_session_on_b_rewrites_b_range_not_a() {
+        let groups = [("/a.pdf", 1u32), ("/b.pdf", 1)];
+        let ranges = dest_ranges_to_rewrite(&groups, &["/a.pdf"]);
+        assert_eq!(
+            ranges,
+            vec![1..2],
+            "H7-range: incomplete A + session links only on B must rewrite B dest pages, not A; got {ranges:?}"
+        );
+        assert!(
+            !ranges.iter().any(|r| r.contains(&0)),
+            "H7-range: must not rewrite A's dest page 0; got {ranges:?}"
+        );
+    }
+
+    #[test]
+    fn mixed_source_b_uri_change_applied_a_unchanged() {
+        let scratch = Scratch::new("h7-edit");
+        let dest = scratch.file("dest.pdf");
+        let mut pdf = PdfFix::new(2, 0, None);
+        pdf.add_link_uri(0, URI_RECT_PDF, "https://a.example/keep");
+        pdf.add_link_uri(1, GOTO_RECT_PDF, "https://b.example/old");
+        pdf.save(&dest);
+
+        let session = [SessionLink {
+            page_index: 1,
+            rect: GOTO_RECT_XYWH,
+            action: LinkAction::Uri {
+                uri: "https://b.example/new".into(),
+            },
+        }];
+        let ranges = dest_ranges_to_rewrite(&[("/a.pdf", 1), ("/b.pdf", 1)], &["/a.pdf"]);
+        let pages: Vec<u32> = ranges.into_iter().flatten().collect();
+        apply_link_annots_for_pages(&dest, &session, &pages).expect("H7-edit apply");
+
+        let a_uris = page_uris(&dest, 1);
+        assert_eq!(
+            a_uris,
+            vec!["https://a.example/keep".to_string()],
+            "H7-edit: A dest URI must stay unchanged; got {a_uris:?}"
+        );
+        let b_uris = page_uris(&dest, 2);
+        assert_eq!(
+            b_uris,
+            vec!["https://b.example/new".to_string()],
+            "H7-edit: B dest URI must be the session URI; got {b_uris:?}"
+        );
+    }
+
+    #[test]
+    fn mixed_source_b_links_removed_a_remain() {
+        let scratch = Scratch::new("h7-delete");
+        let dest = scratch.file("dest.pdf");
+        let mut pdf = PdfFix::new(2, 0, None);
+        pdf.add_link_uri(0, URI_RECT_PDF, "https://a.example/keep");
+        pdf.add_link_uri(1, GOTO_RECT_PDF, "https://b.example/old");
+        pdf.save(&dest);
+
+        let ranges = dest_ranges_to_rewrite(&[("/a.pdf", 1), ("/b.pdf", 1)], &["/a.pdf"]);
+        let pages: Vec<u32> = ranges.into_iter().flatten().collect();
+        apply_link_annots_for_pages(&dest, &[], &pages).expect("H7-delete apply");
+
+        let a_uris = page_uris(&dest, 1);
+        assert_eq!(
+            a_uris,
+            vec!["https://a.example/keep".to_string()],
+            "H7-delete: A dest links must remain; got {a_uris:?}"
+        );
+        let b_uris = page_uris(&dest, 2);
+        assert!(
+            b_uris.is_empty(),
+            "H7-delete: B dest supported links must be gone; got {b_uris:?}"
+        );
     }
 }

--- a/src-tauri/src/pdf_engine/edit_links.rs
+++ b/src-tauri/src/pdf_engine/edit_links.rs
@@ -1,0 +1,1270 @@
+//! PDF `/Link` annotations for Edit PDF (issue #35).
+//!
+//! Shared classifier + list/apply surface. Bodies are fail-today stubs so
+//! tests compile and fail on assertions until impl lands.
+
+use crate::error::AppError;
+use lopdf::{Dictionary, Document, Object, ObjectId};
+use serde::Serialize;
+use std::collections::HashMap;
+use std::path::Path;
+
+/// Outline-sized load gate — same bound as [`super::outline`].
+const MAX_LINK_BYTES: u64 = 400 * 1024 * 1024;
+const MAX_LINKS: usize = 5000;
+
+/// Classification of a link action (URI / in-document GoTo / leave-alone).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LinkActionClass {
+    Uri,
+    GoTo,
+    Unsupported,
+}
+
+/// Supported session/list action: allowlisted URI or 0-based dest page.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LinkAction {
+    Uri { uri: String },
+    GoTo { dest_page_index: u32 },
+}
+
+/// A supported `/Link` listed from a source PDF.
+///
+/// `rect` is unrotated user space `[x, y, w, h]` (same as `EditObject.rect`).
+#[derive(Debug, Clone, PartialEq)]
+pub struct ListedLink {
+    pub page_index: u32,
+    pub rect: [f64; 4],
+    pub action: LinkAction,
+}
+
+/// A session-owned supported link to write onto a staged dest PDF.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SessionLink {
+    pub page_index: u32,
+    pub rect: [f64; 4],
+    pub action: LinkAction,
+}
+
+/// IPC DTO for `list_pdf_links` (paths in, JSON out).
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PdfLinkDto {
+    pub page_index: u32,
+    pub rect: PdfRectDto,
+    pub action: PdfLinkActionDto,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PdfRectDto {
+    pub x: f64,
+    pub y: f64,
+    pub w: f64,
+    pub h: f64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "type", rename_all = "camelCase")]
+pub enum PdfLinkActionDto {
+    Uri {
+        uri: String,
+    },
+    Goto {
+        #[serde(rename = "destPageIndex")]
+        dest_page_index: u32,
+    },
+}
+
+/// Write allowlist: `https` / `http` / `mailto` only (frozen #35 policy).
+pub fn uri_is_allowed(uri: &str) -> bool {
+    let Some(scheme) = uri_scheme(uri) else {
+        return false;
+    };
+    matches!(scheme, "https" | "http" | "mailto")
+}
+
+/// Classify a PDF link action.
+///
+/// `s` is the `/S` name (`URI`, `GoTo`, `Launch`, `GoToR`, `JavaScript`, …).
+/// `uri` is `/URI` when `s` is `URI`. `dest_is_named` is true when `/D` is a
+/// name or string (named dest — unsupported, leave).
+pub fn classify_link_action(s: &str, uri: Option<&str>, dest_is_named: bool) -> LinkActionClass {
+    if s.eq_ignore_ascii_case("URI") {
+        return match uri {
+            Some(u) if uri_is_allowed(u) => LinkActionClass::Uri,
+            _ => LinkActionClass::Unsupported,
+        };
+    }
+    if s.eq_ignore_ascii_case("GoTo") {
+        return if dest_is_named {
+            LinkActionClass::Unsupported
+        } else {
+            LinkActionClass::GoTo
+        };
+    }
+    LinkActionClass::Unsupported
+}
+
+/// List supported URI / in-document GoTo `/Link` annots.
+///
+/// Rects are the written unrotated `/Rect` values as `[x, y, w, h]`, not
+/// display-swapped for `/Rotate`.
+pub fn list_link_annots(path: &Path) -> Result<Vec<ListedLink>, AppError> {
+    let meta = match std::fs::metadata(path) {
+        Ok(m) => m,
+        Err(_) => return Ok(Vec::new()),
+    };
+    if meta.len() > MAX_LINK_BYTES {
+        return Ok(Vec::new());
+    }
+    let doc = match Document::load(path) {
+        Ok(d) => d,
+        Err(_) => return Ok(Vec::new()),
+    };
+    let page_index_of = page_index_map(&doc);
+    let mut out = Vec::new();
+    let pages = doc.get_pages();
+    let mut nums: Vec<u32> = pages.keys().copied().collect();
+    nums.sort_unstable();
+    for num in nums {
+        if out.len() >= MAX_LINKS {
+            break;
+        }
+        let Some(&page_id) = pages.get(&num) else {
+            continue;
+        };
+        for raw in page_annot_objects(&doc, page_id) {
+            if out.len() >= MAX_LINKS {
+                break;
+            }
+            let Some(listed) = listed_from_annot(&doc, &raw, num.saturating_sub(1), &page_index_of)
+            else {
+                continue;
+            };
+            out.push(listed);
+        }
+    }
+    Ok(out)
+}
+
+/// Replace the dest page's supported-Link set with `links`.
+///
+/// Copy through every non-Link annot and every unsupported Link. Reject
+/// writing a non-allowlisted URI with an actionable [`AppError`].
+pub fn apply_link_annots(staged: &Path, links: &[SessionLink]) -> Result<(), AppError> {
+    for link in links {
+        if let LinkAction::Uri { uri } = &link.action {
+            if !uri_is_allowed(uri) {
+                return Err(unsafe_uri_error(uri));
+            }
+        }
+    }
+
+    let mut doc = Document::load(staged)
+        .map_err(|e| AppError::engine_failed(format!("Could not read the staged PDF: {e}")))?;
+    let pages = doc.get_pages();
+    let page_index_of = page_index_map(&doc);
+    let mut page_ids: Vec<(u32, ObjectId)> = pages.iter().map(|(&n, &id)| (n, id)).collect();
+    page_ids.sort_by_key(|(n, _)| *n);
+
+    let mut by_page: HashMap<u32, Vec<&SessionLink>> = HashMap::new();
+    for link in links {
+        if (link.page_index as usize) >= page_ids.len() {
+            return Err(AppError::new(
+                "BAD_EDIT",
+                "Link page is out of range",
+                format!(
+                    "A link points at page {}, but this PDF has {} page{}.",
+                    link.page_index + 1,
+                    page_ids.len(),
+                    if page_ids.len() == 1 { "" } else { "s" }
+                ),
+            )
+            .with_suggestion("Pick a page that exists in the document."));
+        }
+        by_page.entry(link.page_index).or_default().push(link);
+    }
+
+    for (num, page_id) in &page_ids {
+        let page_index = num.saturating_sub(1);
+        let existing = page_annot_objects(&doc, *page_id);
+        let mut kept: Vec<Object> = Vec::new();
+        for raw in existing {
+            if annot_is_supported_link(&doc, &raw, &page_index_of) {
+                continue;
+            }
+            kept.push(raw);
+        }
+        let session = by_page.get(&page_index).map(Vec::as_slice).unwrap_or(&[]);
+        for link in session {
+            let annot_id = add_session_link(&mut doc, link, &page_ids)?;
+            kept.push(annot_id.into());
+        }
+        set_page_annots(&mut doc, *page_id, kept)?;
+    }
+
+    doc.save(staged)
+        .map_err(|e| AppError::io("Could not write link annotations.", e))?;
+    Ok(())
+}
+
+/// True when dest will still have any annot after apply (leftover ∪ added).
+pub fn expected_dest_has_annots(staged: &Path, links: &[SessionLink]) -> Result<bool, AppError> {
+    if !links.is_empty() {
+        return Ok(true);
+    }
+    dest_has_leftover_annots(staged)
+}
+
+/// True when any dest annot is a supported URI/GoTo Link (apply would rewrite).
+pub fn dest_has_supported_links(staged: &Path) -> Result<bool, AppError> {
+    let doc = Document::load(staged)
+        .map_err(|e| AppError::engine_failed(format!("Could not read the staged PDF: {e}")))?;
+    let page_index_of = page_index_map(&doc);
+    for id in doc.get_pages().values() {
+        for raw in page_annot_objects(&doc, *id) {
+            if annot_is_supported_link(&doc, &raw, &page_index_of) {
+                return Ok(true);
+            }
+        }
+    }
+    Ok(false)
+}
+
+/// Command helper: size-gated list as JSON DTOs.
+pub fn list_pdf_links_cmd(path: &str) -> Result<Vec<PdfLinkDto>, AppError> {
+    let listed = list_link_annots(Path::new(path))?;
+    Ok(listed.into_iter().map(listed_to_dto).collect())
+}
+
+pub fn unsafe_uri_error(uri: &str) -> AppError {
+    AppError::new(
+        "UNSAFE_URI",
+        "This link is not allowed",
+        format!("OffPDF cannot write a link to \"{uri}\"."),
+    )
+    .with_suggestion("Use an https, http, or mailto address.")
+}
+
+fn listed_to_dto(link: ListedLink) -> PdfLinkDto {
+    PdfLinkDto {
+        page_index: link.page_index,
+        rect: PdfRectDto {
+            x: link.rect[0],
+            y: link.rect[1],
+            w: link.rect[2],
+            h: link.rect[3],
+        },
+        action: match link.action {
+            LinkAction::Uri { uri } => PdfLinkActionDto::Uri { uri },
+            LinkAction::GoTo { dest_page_index } => PdfLinkActionDto::Goto { dest_page_index },
+        },
+    }
+}
+
+fn uri_scheme(uri: &str) -> Option<&str> {
+    let s = uri.trim();
+    let colon = s.find(':')?;
+    let scheme = &s[..colon];
+    if scheme.is_empty() {
+        return None;
+    }
+    let ok = scheme.bytes().enumerate().all(|(i, b)| {
+        if i == 0 {
+            b.is_ascii_alphabetic()
+        } else {
+            b.is_ascii_alphanumeric() || b == b'+' || b == b'-' || b == b'.'
+        }
+    });
+    if !ok {
+        return None;
+    }
+    // Lowercase compare without allocating when already ASCII-lower.
+    // Callers only match a tiny allowlist; a small String is fine.
+    None.or_else(|| {
+        let lower = scheme.to_ascii_lowercase();
+        // Leak-free: compare via a local then map back is awkward; return owned via match in caller.
+        // Re-parse by returning a static when it matches.
+        match lower.as_str() {
+            "https" => Some("https"),
+            "http" => Some("http"),
+            "mailto" => Some("mailto"),
+            "javascript" => Some("javascript"),
+            "file" => Some("file"),
+            "data" => Some("data"),
+            "ftp" => Some("ftp"),
+            "vbscript" => Some("vbscript"),
+            _ => Some("other"),
+        }
+    })
+}
+
+fn dest_has_leftover_annots(staged: &Path) -> Result<bool, AppError> {
+    let doc = Document::load(staged)
+        .map_err(|e| AppError::engine_failed(format!("Could not read the staged PDF: {e}")))?;
+    let page_index_of = page_index_map(&doc);
+    for id in doc.get_pages().values() {
+        for raw in page_annot_objects(&doc, *id) {
+            if !annot_is_supported_link(&doc, &raw, &page_index_of) {
+                // Any leftover object (non-Link or unsupported Link). Empty Annots
+                // arrays still count as leftover only if they hold an object.
+                if resolve_dict(&doc, &raw).is_some() {
+                    return Ok(true);
+                }
+            }
+        }
+    }
+    Ok(false)
+}
+
+fn page_index_map(doc: &Document) -> HashMap<ObjectId, u32> {
+    let mut map = HashMap::new();
+    for (num, id) in doc.get_pages() {
+        map.insert(id, num.saturating_sub(1));
+    }
+    map
+}
+
+fn page_annot_objects(doc: &Document, page_id: ObjectId) -> Vec<Object> {
+    let Ok(page) = doc.get_dictionary(page_id) else {
+        return Vec::new();
+    };
+    match page.get(b"Annots") {
+        Ok(Object::Array(a)) => a.clone(),
+        Ok(Object::Reference(r)) => doc
+            .get_object(*r)
+            .ok()
+            .and_then(|o| o.as_array().ok())
+            .cloned()
+            .unwrap_or_default(),
+        _ => Vec::new(),
+    }
+}
+
+fn resolve_dict<'a>(doc: &'a Document, obj: &'a Object) -> Option<&'a Dictionary> {
+    match obj {
+        Object::Dictionary(d) => Some(d),
+        Object::Reference(id) => doc.get_dictionary(*id).ok(),
+        _ => None,
+    }
+}
+
+fn as_name(obj: &Object) -> Option<String> {
+    match obj {
+        Object::Name(n) => Some(String::from_utf8_lossy(n).into_owned()),
+        _ => None,
+    }
+}
+
+fn pdf_string(obj: &Object) -> Option<String> {
+    match obj {
+        Object::String(b, _) => Some(String::from_utf8_lossy(b).into_owned()),
+        _ => {
+            let s = lopdf::decode_text_string(obj).ok()?;
+            if s.is_empty() {
+                None
+            } else {
+                Some(s)
+            }
+        }
+    }
+}
+
+fn as_nums(obj: &Object) -> Option<Vec<f64>> {
+    let Object::Array(a) = obj else {
+        return None;
+    };
+    Some(
+        a.iter()
+            .filter_map(|o| match o {
+                Object::Integer(i) => Some(*i as f64),
+                Object::Real(r) => Some(*r as f64),
+                _ => None,
+            })
+            .collect(),
+    )
+}
+
+fn dest_is_named(doc: &Document, dest: &Object) -> bool {
+    match dest {
+        Object::Array(_) => false,
+        Object::Name(_) | Object::String(_, _) => true,
+        Object::Reference(r) => match doc.get_object(*r) {
+            Ok(Object::Array(_)) => false,
+            Ok(Object::Name(_) | Object::String(_, _)) => true,
+            _ => true,
+        },
+        _ => true,
+    }
+}
+
+fn dest_page_index(
+    doc: &Document,
+    dest: &Object,
+    page_index_of: &HashMap<ObjectId, u32>,
+) -> Option<u32> {
+    let arr = match dest {
+        Object::Array(a) => a,
+        Object::Reference(r) => doc.get_object(*r).ok()?.as_array().ok()?,
+        _ => return None,
+    };
+    let page_id = arr.first()?.as_reference().ok()?;
+    page_index_of.get(&page_id).copied()
+}
+
+struct ParsedLink<'a> {
+    class: LinkActionClass,
+    uri: Option<String>,
+    dest_page_index: Option<u32>,
+    rect: [f64; 4],
+    _annot: &'a Dictionary,
+}
+
+fn parse_link_annot<'a>(
+    doc: &'a Document,
+    raw: &'a Object,
+    page_index_of: &HashMap<ObjectId, u32>,
+) -> Option<ParsedLink<'a>> {
+    let annot = resolve_dict(doc, raw)?;
+    let subtype = annot.get(b"Subtype").ok().and_then(as_name)?;
+    if !subtype.eq_ignore_ascii_case("Link") {
+        return None;
+    }
+    let rect = annot
+        .get(b"Rect")
+        .ok()
+        .and_then(as_nums)
+        .and_then(|v| {
+            (v.len() == 4).then_some({
+                let x0 = v[0];
+                let y0 = v[1];
+                let x1 = v[2];
+                let y1 = v[3];
+                [x0.min(x1), y0.min(y1), (x1 - x0).abs(), (y1 - y0).abs()]
+            })
+        })
+        .unwrap_or([0.0, 0.0, 0.0, 0.0]);
+
+    if let Some(action_obj) = annot.get(b"A").ok() {
+        let action = resolve_dict(doc, action_obj)?;
+        let s = action.get(b"S").ok().and_then(as_name).unwrap_or_default();
+        let uri = action.get(b"URI").ok().and_then(pdf_string);
+        let dest = action.get(b"D").ok();
+        let named = dest.map(|d| dest_is_named(doc, d)).unwrap_or(false);
+        let class = classify_link_action(&s, uri.as_deref(), named);
+        let dest_page = dest.and_then(|d| dest_page_index(doc, d, page_index_of));
+        return Some(ParsedLink {
+            class,
+            uri,
+            dest_page_index: dest_page,
+            rect,
+            _annot: annot,
+        });
+    }
+
+    if let Some(dest) = annot.get(b"Dest").ok() {
+        let named = dest_is_named(doc, dest);
+        let class = classify_link_action("GoTo", None, named);
+        let dest_page = dest_page_index(doc, dest, page_index_of);
+        return Some(ParsedLink {
+            class,
+            uri: None,
+            dest_page_index: dest_page,
+            rect,
+            _annot: annot,
+        });
+    }
+
+    Some(ParsedLink {
+        class: LinkActionClass::Unsupported,
+        uri: None,
+        dest_page_index: None,
+        rect,
+        _annot: annot,
+    })
+}
+
+fn listed_from_annot(
+    doc: &Document,
+    raw: &Object,
+    page_index: u32,
+    page_index_of: &HashMap<ObjectId, u32>,
+) -> Option<ListedLink> {
+    let parsed = parse_link_annot(doc, raw, page_index_of)?;
+    match parsed.class {
+        LinkActionClass::Uri => {
+            let uri = parsed.uri?;
+            Some(ListedLink {
+                page_index,
+                rect: parsed.rect,
+                action: LinkAction::Uri { uri },
+            })
+        }
+        LinkActionClass::GoTo => {
+            let dest_page_index = parsed.dest_page_index?;
+            Some(ListedLink {
+                page_index,
+                rect: parsed.rect,
+                action: LinkAction::GoTo { dest_page_index },
+            })
+        }
+        LinkActionClass::Unsupported => None,
+    }
+}
+
+fn annot_is_supported_link(
+    doc: &Document,
+    raw: &Object,
+    page_index_of: &HashMap<ObjectId, u32>,
+) -> bool {
+    // Same set list_link_annots hydrates: allowlisted URI or resolvable
+    // in-document GoTo. Unresolvable /D arrays stay leftover and copy through.
+    listed_from_annot(doc, raw, 0, page_index_of).is_some()
+}
+
+fn add_session_link(
+    doc: &mut Document,
+    link: &SessionLink,
+    page_ids: &[(u32, ObjectId)],
+) -> Result<ObjectId, AppError> {
+    let [x, y, w, h] = link.rect;
+    let rect = Object::Array(vec![
+        Object::Real(x as f32),
+        Object::Real(y as f32),
+        Object::Real((x + w) as f32),
+        Object::Real((y + h) as f32),
+    ]);
+    let mut action = Dictionary::new();
+    match &link.action {
+        LinkAction::Uri { uri } => {
+            action.set("S", "URI");
+            action.set("URI", Object::string_literal(uri.as_str()));
+        }
+        LinkAction::GoTo { dest_page_index } => {
+            let dest_1 = dest_page_index + 1;
+            let dest_id = page_ids
+                .iter()
+                .find(|(n, _)| *n == dest_1)
+                .map(|(_, id)| *id)
+                .ok_or_else(|| {
+                    AppError::new(
+                        "BAD_EDIT",
+                        "Link destination is out of range",
+                        format!(
+                            "A link points at page {dest_1}, but this PDF has {} page{}.",
+                            page_ids.len(),
+                            if page_ids.len() == 1 { "" } else { "s" }
+                        ),
+                    )
+                    .with_suggestion("Pick a page that exists in the document.")
+                })?;
+            action.set("S", "GoTo");
+            action.set(
+                "D",
+                Object::Array(vec![dest_id.into(), Object::Name(b"Fit".to_vec())]),
+            );
+        }
+    }
+    let mut annot = Dictionary::new();
+    annot.set("Type", "Annot");
+    annot.set("Subtype", "Link");
+    annot.set("Rect", rect);
+    annot.set(
+        "Border",
+        Object::Array(vec![
+            Object::Integer(0),
+            Object::Integer(0),
+            Object::Integer(0),
+        ]),
+    );
+    annot.set("A", Object::Dictionary(action));
+    Ok(doc.add_object(Object::Dictionary(annot)))
+}
+
+fn set_page_annots(
+    doc: &mut Document,
+    page_id: ObjectId,
+    annots: Vec<Object>,
+) -> Result<(), AppError> {
+    let page = doc
+        .get_object_mut(page_id)
+        .and_then(|o| o.as_dict_mut())
+        .map_err(|e| AppError::engine_failed(format!("Could not update page annotations: {e}")))?;
+    if annots.is_empty() {
+        page.remove(b"Annots");
+    } else {
+        page.set("Annots", Object::Array(annots));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use lopdf::{Dictionary, Document, Object, ObjectId, Stream};
+    use std::path::{Path, PathBuf};
+
+    struct Scratch(PathBuf);
+
+    impl Scratch {
+        fn new(name: &str) -> Self {
+            let dir = std::env::temp_dir().join(format!(
+                "offpdf-links-{}-{}-{}",
+                name,
+                std::process::id(),
+                std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .map(|d| d.as_nanos())
+                    .unwrap_or(0)
+            ));
+            std::fs::create_dir_all(&dir).unwrap();
+            Self(dir)
+        }
+
+        fn file(&self, name: &str) -> PathBuf {
+            self.0.join(name)
+        }
+    }
+
+    impl Drop for Scratch {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
+    fn box_obj(b: [i64; 4]) -> Object {
+        Object::Array(b.into_iter().map(Object::Integer).collect())
+    }
+
+    fn name(s: &str) -> Object {
+        Object::Name(s.as_bytes().to_vec())
+    }
+
+    struct PdfFix {
+        doc: Document,
+        page_ids: Vec<ObjectId>,
+    }
+
+    impl PdfFix {
+        fn new(n_pages: usize, rotate: i64, crop: Option<[i64; 4]>) -> Self {
+            let mut doc = Document::with_version("1.5");
+            let pages_id = doc.new_object_id();
+            let mut page_ids = Vec::with_capacity(n_pages);
+            for _ in 0..n_pages {
+                let content_id = doc.add_object(Object::Stream(Stream::new(
+                    Dictionary::new(),
+                    b"BT /F1 12 Tf 72 720 Td (Hello) Tj ET".to_vec(),
+                )));
+                let mut page = Dictionary::new();
+                page.set("Type", "Page");
+                page.set("Parent", pages_id);
+                page.set("MediaBox", box_obj([0, 0, 612, 792]));
+                if let Some(c) = crop {
+                    page.set("CropBox", box_obj(c));
+                }
+                if rotate != 0 {
+                    page.set("Rotate", Object::Integer(rotate));
+                }
+                page.set("Contents", content_id);
+                page_ids.push(doc.add_object(Object::Dictionary(page)));
+            }
+
+            let mut pages = Dictionary::new();
+            pages.set("Type", "Pages");
+            pages.set(
+                "Kids",
+                Object::Array(page_ids.iter().copied().map(Object::from).collect()),
+            );
+            pages.set("Count", Object::Integer(n_pages as i64));
+            doc.objects.insert(pages_id, Object::Dictionary(pages));
+
+            let mut catalog = Dictionary::new();
+            catalog.set("Type", "Catalog");
+            catalog.set("Pages", pages_id);
+            let catalog_id = doc.add_object(Object::Dictionary(catalog));
+            doc.trailer.set("Root", catalog_id);
+            Self { doc, page_ids }
+        }
+
+        fn push_annot(&mut self, page_index: usize, dict: Dictionary) {
+            let annot_id = self.doc.add_object(Object::Dictionary(dict));
+            let page_id = self.page_ids[page_index];
+            let mut arr = match self.doc.get_dictionary(page_id).ok().and_then(|p| {
+                p.get(b"Annots").ok().and_then(|o| match o {
+                    Object::Array(a) => Some(a.clone()),
+                    _ => None,
+                })
+            }) {
+                Some(a) => a,
+                None => Vec::new(),
+            };
+            arr.push(annot_id.into());
+            if let Ok(Object::Dictionary(page)) = self.doc.get_object_mut(page_id) {
+                page.set("Annots", Object::Array(arr));
+            }
+        }
+
+        fn add_link_uri(&mut self, page_index: usize, rect: [i64; 4], uri: &str) {
+            let mut action = Dictionary::new();
+            action.set("S", name("URI"));
+            action.set("URI", Object::string_literal(uri));
+            let mut annot = Dictionary::new();
+            annot.set("Type", "Annot");
+            annot.set("Subtype", "Link");
+            annot.set("Rect", box_obj(rect));
+            annot.set("A", Object::Dictionary(action));
+            self.push_annot(page_index, annot);
+        }
+
+        fn add_link_goto(&mut self, page_index: usize, rect: [i64; 4], dest_page: usize) {
+            let dest_id = self.page_ids[dest_page];
+            let mut action = Dictionary::new();
+            action.set("S", name("GoTo"));
+            action.set("D", Object::Array(vec![dest_id.into(), name("Fit")]));
+            let mut annot = Dictionary::new();
+            annot.set("Type", "Annot");
+            annot.set("Subtype", "Link");
+            annot.set("Rect", box_obj(rect));
+            annot.set("A", Object::Dictionary(action));
+            self.push_annot(page_index, annot);
+        }
+
+        fn add_highlight(&mut self, page_index: usize, rect: [i64; 4], contents: &str) {
+            let mut annot = Dictionary::new();
+            annot.set("Type", "Annot");
+            annot.set("Subtype", "Highlight");
+            annot.set("Rect", box_obj(rect));
+            annot.set("Contents", Object::string_literal(contents));
+            self.push_annot(page_index, annot);
+        }
+
+        fn save(&mut self, path: &Path) {
+            self.doc.save(path).expect("write link fixture");
+        }
+    }
+
+    struct InspectedAnnot {
+        subtype: String,
+        rect: [f64; 4],
+        action_s: Option<String>,
+        uri: Option<String>,
+        dest_page_index: Option<u32>,
+        contents: Option<String>,
+        has_annots_key: bool,
+    }
+
+    fn as_name(obj: &Object) -> Option<String> {
+        match obj {
+            Object::Name(n) => Some(String::from_utf8_lossy(n).into_owned()),
+            _ => None,
+        }
+    }
+
+    fn as_nums(obj: &Object) -> Option<Vec<f64>> {
+        let Object::Array(a) = obj else {
+            return None;
+        };
+        Some(
+            a.iter()
+                .filter_map(|o| match o {
+                    Object::Integer(i) => Some(*i as f64),
+                    Object::Real(r) => Some(*r as f64),
+                    _ => None,
+                })
+                .collect(),
+        )
+    }
+
+    fn pdf_string(obj: &Object) -> Option<String> {
+        match obj {
+            Object::String(b, _) => Some(String::from_utf8_lossy(b).into_owned()),
+            _ => {
+                let s = lopdf::decode_text_string(obj).ok()?;
+                if s.is_empty() {
+                    None
+                } else {
+                    Some(s)
+                }
+            }
+        }
+    }
+
+    fn resolve_dict<'a>(doc: &'a Document, obj: &'a Object) -> Option<&'a Dictionary> {
+        match obj {
+            Object::Dictionary(d) => Some(d),
+            Object::Reference(id) => doc.get_dictionary(*id).ok(),
+            _ => None,
+        }
+    }
+
+    fn page_index_of(doc: &Document, id: ObjectId) -> Option<u32> {
+        doc.get_pages()
+            .iter()
+            .find_map(|(num, pid)| (*pid == id).then_some(*num - 1))
+    }
+
+    fn page_has_annots_key(path: &Path, page_1based: u32) -> bool {
+        let doc = Document::load(path).expect("load dest");
+        let Some(id) = doc.get_pages().get(&page_1based).copied() else {
+            return false;
+        };
+        doc.get_dictionary(id)
+            .ok()
+            .and_then(|p| p.get(b"Annots").ok())
+            .is_some()
+    }
+
+    fn inspect_page_annots(path: &Path, page_1based: u32) -> Vec<InspectedAnnot> {
+        let doc = Document::load(path).expect("load dest");
+        let Some(id) = doc.get_pages().get(&page_1based).copied() else {
+            return Vec::new();
+        };
+        let Ok(page) = doc.get_dictionary(id) else {
+            return Vec::new();
+        };
+        let has_annots_key = page.get(b"Annots").is_ok();
+        let annot_objs: Vec<Object> = match page.get(b"Annots") {
+            Ok(Object::Array(a)) => a.clone(),
+            Ok(Object::Reference(r)) => doc
+                .get_object(*r)
+                .ok()
+                .and_then(|o| o.as_array().ok())
+                .cloned()
+                .unwrap_or_default(),
+            _ => Vec::new(),
+        };
+        annot_objs
+            .iter()
+            .filter_map(|obj| {
+                let annot = resolve_dict(&doc, obj)?;
+                let subtype = annot
+                    .get(b"Subtype")
+                    .ok()
+                    .and_then(as_name)
+                    .unwrap_or_default();
+                let rect = annot
+                    .get(b"Rect")
+                    .ok()
+                    .and_then(as_nums)
+                    .and_then(|v| (v.len() == 4).then_some([v[0], v[1], v[2], v[3]]))
+                    .unwrap_or([0.0, 0.0, 0.0, 0.0]);
+                let action = annot.get(b"A").ok().and_then(|a| resolve_dict(&doc, a));
+                let action_s = action.and_then(|a| a.get(b"S").ok().and_then(as_name));
+                let uri = action.and_then(|a| a.get(b"URI").ok().and_then(pdf_string));
+                let dest_page_index = action.and_then(|a| {
+                    let dest = a.get(b"D").ok()?;
+                    let arr = match dest {
+                        Object::Array(v) => v,
+                        Object::Reference(r) => doc.get_object(*r).ok()?.as_array().ok()?,
+                        _ => return None,
+                    };
+                    let first = arr.first()?;
+                    let page_id = first.as_reference().ok()?;
+                    page_index_of(&doc, page_id)
+                });
+                let contents = annot.get(b"Contents").ok().and_then(pdf_string);
+                Some(InspectedAnnot {
+                    subtype,
+                    rect,
+                    action_s,
+                    uri,
+                    dest_page_index,
+                    contents,
+                    has_annots_key,
+                })
+            })
+            .collect()
+    }
+
+    fn rects_near(a: [f64; 4], b: [f64; 4]) -> bool {
+        a.iter().zip(b.iter()).all(|(x, y)| (x - y).abs() < 0.5)
+    }
+
+    fn xywh_to_pdf(r: [f64; 4]) -> [f64; 4] {
+        [r[0], r[1], r[0] + r[2], r[1] + r[3]]
+    }
+
+    fn assert_actionable(err: &AppError, what: &str) {
+        assert!(
+            !err.title.trim().is_empty(),
+            "{what}: AppError must have a title; got {err:?}"
+        );
+        assert!(
+            !err.message.trim().is_empty(),
+            "{what}: AppError must have a message; got {err:?}"
+        );
+        assert!(
+            err.suggestion
+                .as_deref()
+                .map(|s| !s.trim().is_empty())
+                .unwrap_or(false),
+            "{what}: AppError must have a suggestion; got {err:?}"
+        );
+    }
+
+    const URI_RECT_XYWH: [f64; 4] = [100.0, 200.0, 80.0, 40.0];
+    const GOTO_RECT_XYWH: [f64; 4] = [200.0, 300.0, 80.0, 60.0];
+    const URI_RECT_PDF: [i64; 4] = [100, 200, 180, 240];
+    const GOTO_RECT_PDF: [i64; 4] = [200, 300, 280, 360];
+    const HIGHLIGHT_RECT_PDF: [i64; 4] = [50, 50, 150, 80];
+
+    // --- L3 allowlist / classifier -----------------------------------------
+
+    #[test]
+    fn uri_allowlist_https_http_mailto_only() {
+        let allowed = [
+            "https://example.com/a",
+            "http://example.com/b",
+            "mailto:user@example.com",
+        ];
+        let rejected = [
+            "javascript:alert(1)",
+            "file:///tmp/x",
+            "data:text/html,hi",
+            "ftp://example.com/f",
+            "vbscript:msgbox",
+            "myapp:custom",
+        ];
+        for uri in allowed {
+            assert!(uri_is_allowed(uri), "L3: {uri} must be allowed");
+        }
+        for uri in rejected {
+            assert!(!uri_is_allowed(uri), "L3: {uri} must be rejected");
+        }
+    }
+
+    #[test]
+    fn classify_allowlisted_uri_and_explicit_goto_are_supported() {
+        assert_eq!(
+            classify_link_action("URI", Some("https://example.com"), false),
+            LinkActionClass::Uri,
+            "L3: https URI must be Uri"
+        );
+        assert_eq!(
+            classify_link_action("URI", Some("http://example.com"), false),
+            LinkActionClass::Uri,
+            "L3: http URI must be Uri"
+        );
+        assert_eq!(
+            classify_link_action("URI", Some("mailto:a@b.com"), false),
+            LinkActionClass::Uri,
+            "L3: mailto URI must be Uri"
+        );
+        assert_eq!(
+            classify_link_action("GoTo", None, false),
+            LinkActionClass::GoTo,
+            "L3: explicit GoTo must be GoTo"
+        );
+    }
+
+    #[test]
+    fn classify_javascript_file_data_uri_are_unsupported() {
+        for uri in ["javascript:alert(1)", "file:///tmp/x", "data:text/plain,x"] {
+            assert_eq!(
+                classify_link_action("URI", Some(uri), false),
+                LinkActionClass::Unsupported,
+                "L3: classify {uri} must be Unsupported"
+            );
+        }
+    }
+
+    #[test]
+    fn classify_launch_gotor_js_named_dest_are_unsupported() {
+        assert_eq!(
+            classify_link_action("Launch", None, false),
+            LinkActionClass::Unsupported,
+            "L3: classify Launch must be Unsupported"
+        );
+        assert_eq!(
+            classify_link_action("GoToR", None, false),
+            LinkActionClass::Unsupported,
+            "L3: classify GoToR must be Unsupported"
+        );
+        assert_eq!(
+            classify_link_action("JavaScript", None, false),
+            LinkActionClass::Unsupported,
+            "L3: classify JavaScript action must be Unsupported"
+        );
+        assert_eq!(
+            classify_link_action("GoTo", None, true),
+            LinkActionClass::Unsupported,
+            "L3: classify named dest must be Unsupported"
+        );
+    }
+
+    #[test]
+    fn apply_rejected_uri_is_app_error_and_leaves_dest() {
+        let scratch = Scratch::new("l3-write");
+        let dest = scratch.file("dest.pdf");
+        PdfFix::new(1, 0, None).save(&dest);
+        let before = std::fs::read(&dest).unwrap();
+
+        for uri in [
+            "javascript:alert(1)",
+            "file:///tmp/x",
+            "data:text/html,hi",
+            "ftp://example.com/f",
+            "vbscript:msgbox",
+            "myapp:custom",
+        ] {
+            std::fs::write(&dest, &before).unwrap();
+            let links = [SessionLink {
+                page_index: 0,
+                rect: URI_RECT_XYWH,
+                action: LinkAction::Uri {
+                    uri: uri.to_string(),
+                },
+            }];
+            let err = apply_link_annots(&dest, &links)
+                .expect_err(&format!("L3: writing {uri} must be AppError"));
+            assert_actionable(&err, &format!("L3 {uri}"));
+            assert_eq!(
+                std::fs::read(&dest).unwrap(),
+                before,
+                "L3: dest bytes must stay unchanged after rejected {uri}"
+            );
+        }
+    }
+
+    // --- L1 list -----------------------------------------------------------
+
+    #[test]
+    fn list_uri_and_goto_rects_are_unrotated_on_rotate_90_crop() {
+        let scratch = Scratch::new("l1");
+        let src = scratch.file("src.pdf");
+        let mut pdf = PdfFix::new(1, 90, Some([72, 72, 540, 720]));
+        pdf.add_link_uri(0, URI_RECT_PDF, "https://example.com/uri");
+        pdf.add_link_goto(0, GOTO_RECT_PDF, 0);
+        pdf.save(&src);
+
+        let listed = list_link_annots(&src).expect("L1: list_link_annots");
+        assert!(
+            !listed.is_empty(),
+            "L1: list_link_annots must return the URI and GoTo on a Rotate 90 Crop≠Media page; got empty"
+        );
+
+        let uri = listed.iter().find(
+            |l| matches!(&l.action, LinkAction::Uri { uri } if uri == "https://example.com/uri"),
+        );
+        let goto = listed
+            .iter()
+            .find(|l| matches!(&l.action, LinkAction::GoTo { dest_page_index: 0 }));
+        let uri = uri.expect("L1: listed set must include the URI link");
+        let goto = goto.expect("L1: listed set must include the GoTo link");
+        assert_eq!(uri.page_index, 0);
+        assert_eq!(goto.page_index, 0);
+        assert!(
+            rects_near(uri.rect, URI_RECT_XYWH),
+            "L1: listed URI rect must be unrotated /Rect as [x,y,w,h], not display-swapped; got {:?}",
+            uri.rect
+        );
+        assert!(
+            rects_near(goto.rect, GOTO_RECT_XYWH),
+            "L1: listed GoTo rect must be unrotated /Rect as [x,y,w,h], not display-swapped; got {:?}",
+            goto.rect
+        );
+    }
+
+    // --- L2 apply add ------------------------------------------------------
+
+    #[test]
+    fn apply_writes_uri_and_goto_link_annots() {
+        let scratch = Scratch::new("l2");
+        let dest = scratch.file("dest.pdf");
+        PdfFix::new(2, 0, None).save(&dest);
+
+        let links = [
+            SessionLink {
+                page_index: 0,
+                rect: URI_RECT_XYWH,
+                action: LinkAction::Uri {
+                    uri: "https://example.com/new".into(),
+                },
+            },
+            SessionLink {
+                page_index: 0,
+                rect: GOTO_RECT_XYWH,
+                action: LinkAction::GoTo { dest_page_index: 1 },
+            },
+        ];
+        apply_link_annots(&dest, &links).expect("L2: apply_link_annots");
+
+        let annots = inspect_page_annots(&dest, 1);
+        let uri = annots.iter().find(|a| {
+            a.subtype == "Link"
+                && a.action_s.as_deref() == Some("URI")
+                && a.uri.as_deref() == Some("https://example.com/new")
+        });
+        let goto = annots.iter().find(|a| {
+            a.subtype == "Link"
+                && a.action_s.as_deref() == Some("GoTo")
+                && a.dest_page_index == Some(1)
+        });
+        assert!(
+            uri.is_some(),
+            "L2: dest page /Annots must have /Subtype /Link /A /S /URI; got {:?}",
+            annots
+                .iter()
+                .map(|a| (&a.subtype, &a.action_s, &a.uri))
+                .collect::<Vec<_>>()
+        );
+        assert!(
+            goto.is_some(),
+            "L2: dest page /Annots must have /Subtype /Link /A /S /GoTo dest page 1; got {:?}",
+            annots
+                .iter()
+                .map(|a| (&a.subtype, &a.action_s, a.dest_page_index))
+                .collect::<Vec<_>>()
+        );
+        let uri = uri.unwrap();
+        let goto = goto.unwrap();
+        assert!(
+            rects_near(uri.rect, xywh_to_pdf(URI_RECT_XYWH)),
+            "L2: URI /Rect must be unrotated [x y x+w y+h]; got {:?}",
+            uri.rect
+        );
+        assert!(
+            rects_near(goto.rect, xywh_to_pdf(GOTO_RECT_XYWH)),
+            "L2: GoTo /Rect must be unrotated [x y x+w y+h]; got {:?}",
+            goto.rect
+        );
+    }
+
+    // --- L4 survival (keepGreen-after-impl if no-op leaves dest == copy) ----
+
+    #[test]
+    fn apply_kept_uri_copies_through_highlight() {
+        let scratch = Scratch::new("l4");
+        let dest = scratch.file("dest.pdf");
+        let mut pdf = PdfFix::new(1, 0, None);
+        pdf.add_link_uri(0, URI_RECT_PDF, "https://keep.example/");
+        pdf.add_highlight(0, HIGHLIGHT_RECT_PDF, "keep-me");
+        pdf.save(&dest);
+
+        let links = [SessionLink {
+            page_index: 0,
+            rect: URI_RECT_XYWH,
+            action: LinkAction::Uri {
+                uri: "https://keep.example/".into(),
+            },
+        }];
+        apply_link_annots(&dest, &links).expect("L4: apply_link_annots");
+
+        let annots = inspect_page_annots(&dest, 1);
+        assert!(
+            annots.iter().any(|a| {
+                a.subtype == "Link"
+                    && a.action_s.as_deref() == Some("URI")
+                    && a.uri.as_deref() == Some("https://keep.example/")
+            }),
+            "L4: dest must still have the session URI; got {:?}",
+            annots
+                .iter()
+                .map(|a| (&a.subtype, &a.uri))
+                .collect::<Vec<_>>()
+        );
+        assert!(
+            annots
+                .iter()
+                .any(|a| a.subtype == "Highlight" && a.contents.as_deref() == Some("keep-me")),
+            "L4: dest must copy through the non-Link Highlight; got {:?}",
+            annots
+                .iter()
+                .map(|a| (&a.subtype, &a.contents))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    // --- L6 first Annots key -----------------------------------------------
+
+    #[test]
+    fn apply_first_link_creates_annots_key() {
+        let scratch = Scratch::new("l6");
+        let dest = scratch.file("dest.pdf");
+        PdfFix::new(1, 0, None).save(&dest);
+        assert!(
+            !page_has_annots_key(&dest, 1),
+            "fixture must start with no /Annots"
+        );
+
+        let links = [SessionLink {
+            page_index: 0,
+            rect: URI_RECT_XYWH,
+            action: LinkAction::Uri {
+                uri: "https://example.com/first".into(),
+            },
+        }];
+        apply_link_annots(&dest, &links).expect("L6: apply_link_annots");
+        assert!(
+            page_has_annots_key(&dest, 1),
+            "L6: apply of the first link onto a file with no /Annots must create dest /Annots"
+        );
+        let annots = inspect_page_annots(&dest, 1);
+        assert!(
+            annots.iter().any(|a| {
+                a.has_annots_key
+                    && a.subtype == "Link"
+                    && a.action_s.as_deref() == Some("URI")
+                    && a.uri.as_deref() == Some("https://example.com/first")
+            }),
+            "L6: dest /Annots must contain the new URI Link; got {:?}",
+            annots
+                .iter()
+                .map(|a| (&a.subtype, &a.uri))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    // --- L7 delete one supported, keep non-Link ----------------------------
+
+    #[test]
+    fn apply_deletes_one_uri_and_keeps_highlight() {
+        let scratch = Scratch::new("l7");
+        let dest = scratch.file("dest.pdf");
+        let mut pdf = PdfFix::new(1, 0, None);
+        pdf.add_link_uri(0, URI_RECT_PDF, "https://keep.example/");
+        pdf.add_link_uri(0, GOTO_RECT_PDF, "https://drop.example/");
+        pdf.add_highlight(0, HIGHLIGHT_RECT_PDF, "keep-me");
+        pdf.save(&dest);
+
+        let links = [SessionLink {
+            page_index: 0,
+            rect: URI_RECT_XYWH,
+            action: LinkAction::Uri {
+                uri: "https://keep.example/".into(),
+            },
+        }];
+        apply_link_annots(&dest, &links).expect("L7: apply_link_annots");
+
+        let annots = inspect_page_annots(&dest, 1);
+        let uris: Vec<&str> = annots
+            .iter()
+            .filter(|a| a.subtype == "Link" && a.action_s.as_deref() == Some("URI"))
+            .filter_map(|a| a.uri.as_deref())
+            .collect();
+        assert!(
+            uris.contains(&"https://keep.example/"),
+            "L7: dest must keep the remaining URI; got {uris:?}"
+        );
+        assert!(
+            !uris.contains(&"https://drop.example/"),
+            "L7: dest must drop the deleted URI; still has {uris:?}"
+        );
+        assert_eq!(
+            uris.len(),
+            1,
+            "L7: dest must have exactly one URI Link; got {uris:?}"
+        );
+        assert!(
+            annots
+                .iter()
+                .any(|a| a.subtype == "Highlight" && a.contents.as_deref() == Some("keep-me")),
+            "L7: dest must keep the non-Link Highlight; got {:?}",
+            annots
+                .iter()
+                .map(|a| (&a.subtype, &a.contents))
+                .collect::<Vec<_>>()
+        );
+    }
+}

--- a/src-tauri/src/pdf_engine/edit_links.rs
+++ b/src-tauri/src/pdf_engine/edit_links.rs
@@ -109,39 +109,37 @@ pub fn classify_link_action(s: &str, uri: Option<&str>, dest_is_named: bool) -> 
 /// List supported URI / in-document GoTo `/Link` annots.
 ///
 /// Rects are the written unrotated `/Rect` values as `[x, y, w, h]`, not
-/// display-swapped for `/Rotate`.
+/// display-swapped for `/Rotate`. Oversize files, more than [`MAX_LINKS`]
+/// supported links, a missing path, or an unreadable PDF return an actionable
+/// [`AppError`] — never a silent empty or truncated `Ok`.
 pub fn list_link_annots(path: &Path) -> Result<Vec<ListedLink>, AppError> {
-    let meta = match std::fs::metadata(path) {
-        Ok(m) => m,
-        Err(_) => return Ok(Vec::new()),
-    };
+    let meta = std::fs::metadata(path).map_err(|e| {
+        AppError::io("Could not read the file.", e)
+            .with_suggestion("Check that the PDF still exists and try again.")
+    })?;
     if meta.len() > MAX_LINK_BYTES {
-        return Ok(Vec::new());
+        return Err(file_too_large_for_links());
     }
-    let doc = match Document::load(path) {
-        Ok(d) => d,
-        Err(_) => return Ok(Vec::new()),
-    };
+    let path_str = path.to_string_lossy();
+    let doc = Document::load(path)
+        .map_err(|e| AppError::invalid_pdf(&path_str).with_details(format!("lopdf: {e}")))?;
     let page_index_of = page_index_map(&doc);
     let mut out = Vec::new();
     let pages = doc.get_pages();
     let mut nums: Vec<u32> = pages.keys().copied().collect();
     nums.sort_unstable();
     for num in nums {
-        if out.len() >= MAX_LINKS {
-            break;
-        }
         let Some(&page_id) = pages.get(&num) else {
             continue;
         };
         for raw in page_annot_objects(&doc, page_id) {
-            if out.len() >= MAX_LINKS {
-                break;
-            }
             let Some(listed) = listed_from_annot(&doc, &raw, num.saturating_sub(1), &page_index_of)
             else {
                 continue;
             };
+            if out.len() >= MAX_LINKS {
+                return Err(too_many_links());
+            }
             out.push(listed);
         }
     }
@@ -190,13 +188,20 @@ pub fn apply_link_annots(staged: &Path, links: &[SessionLink]) -> Result<(), App
         let page_index = num.saturating_sub(1);
         let existing = page_annot_objects(&doc, *page_id);
         let mut kept: Vec<Object> = Vec::new();
+        let mut session: Vec<&SessionLink> = by_page.get(&page_index).cloned().unwrap_or_default();
         for raw in existing {
-            if annot_is_supported_link(&doc, &raw, &page_index_of) {
+            if let Some(listed) = listed_from_annot(&doc, &raw, page_index, &page_index_of) {
+                if let Some(i) = session
+                    .iter()
+                    .position(|l| session_matches_listed(l, &listed))
+                {
+                    session.remove(i);
+                    kept.push(raw);
+                }
                 continue;
             }
             kept.push(raw);
         }
-        let session = by_page.get(&page_index).map(Vec::as_slice).unwrap_or(&[]);
         for link in session {
             let annot_id = add_session_link(&mut doc, link, &page_ids)?;
             kept.push(annot_id.into());
@@ -232,6 +237,20 @@ pub fn dest_has_supported_links(staged: &Path) -> Result<bool, AppError> {
     Ok(false)
 }
 
+/// Whether Save should rewrite dest supported `/Link`s.
+///
+/// Incomplete hydrate + empty session must not wipe dest. Complete empty
+/// still deletes (L7).
+pub fn should_rewrite_supported_links(complete: bool, session_len: usize, dest_has: bool) -> bool {
+    if !complete {
+        return false;
+    }
+    if session_len > 0 {
+        return true;
+    }
+    dest_has
+}
+
 /// Command helper: size-gated list as JSON DTOs.
 pub fn list_pdf_links_cmd(path: &str) -> Result<Vec<PdfLinkDto>, AppError> {
     let listed = list_link_annots(Path::new(path))?;
@@ -245,6 +264,32 @@ pub fn unsafe_uri_error(uri: &str) -> AppError {
         format!("OffPDF cannot write a link to \"{uri}\"."),
     )
     .with_suggestion("Use an https, http, or mailto address.")
+}
+
+fn file_too_large_for_links() -> AppError {
+    AppError::new(
+        "FILE_TOO_LARGE",
+        "File too large to read links",
+        "Reading links needs the document loaded into memory, and this file is over 400 MB.",
+    )
+    .with_suggestion("Save stamps only, or split the PDF into smaller documents.")
+}
+
+fn too_many_links() -> AppError {
+    AppError::new(
+        "TOO_MANY_LINKS",
+        "Too many links to edit",
+        "This PDF has more than 5,000 supported links, so OffPDF cannot load them all.",
+    )
+    .with_suggestion("Save stamps only, or split the PDF into smaller documents.")
+}
+
+fn rects_close(a: [f64; 4], b: [f64; 4]) -> bool {
+    a.iter().zip(b.iter()).all(|(x, y)| (x - y).abs() < 0.5)
+}
+
+fn session_matches_listed(link: &SessionLink, listed: &ListedLink) -> bool {
+    rects_close(link.rect, listed.rect) && link.action == listed.action
 }
 
 fn listed_to_dto(link: ListedLink) -> PdfLinkDto {
@@ -739,6 +784,75 @@ mod tests {
             self.push_annot(page_index, annot);
         }
 
+        fn add_n_uri_links(&mut self, page_index: usize, n: usize, uri: &str) {
+            let page_id = self.page_ids[page_index];
+            let mut arr = match self.doc.get_dictionary(page_id).ok().and_then(|p| {
+                p.get(b"Annots").ok().and_then(|o| match o {
+                    Object::Array(a) => Some(a.clone()),
+                    _ => None,
+                })
+            }) {
+                Some(a) => a,
+                None => Vec::new(),
+            };
+            for i in 0..n {
+                let x = (i as i64) % 500;
+                let y = (i as i64) / 500;
+                let mut action = Dictionary::new();
+                action.set("S", name("URI"));
+                action.set("URI", Object::string_literal(uri));
+                let mut annot = Dictionary::new();
+                annot.set("Type", "Annot");
+                annot.set("Subtype", "Link");
+                annot.set("Rect", box_obj([x, y, x + 10, y + 10]));
+                annot.set("A", Object::Dictionary(action));
+                let annot_id = self.doc.add_object(Object::Dictionary(annot));
+                arr.push(annot_id.into());
+            }
+            if let Ok(Object::Dictionary(page)) = self.doc.get_object_mut(page_id) {
+                page.set("Annots", Object::Array(arr));
+            }
+        }
+
+        fn add_link_uri_with_extra_keys(&mut self, page_index: usize, rect: [i64; 4], uri: &str) {
+            let mut action = Dictionary::new();
+            action.set("S", name("URI"));
+            action.set("URI", Object::string_literal(uri));
+            let mut ap = Dictionary::new();
+            ap.set("N", name("Off"));
+            let mut annot = Dictionary::new();
+            annot.set("Type", "Annot");
+            annot.set("Subtype", "Link");
+            annot.set("Rect", box_obj(rect));
+            annot.set("A", Object::Dictionary(action));
+            annot.set(
+                "Border",
+                Object::Array(vec![
+                    Object::Integer(2),
+                    Object::Integer(1),
+                    Object::Integer(3),
+                ]),
+            );
+            annot.set("H", name("I"));
+            annot.set("F", Object::Integer(4));
+            annot.set("AP", Object::Dictionary(ap));
+            annot.set(
+                "QuadPoints",
+                Object::Array(vec![
+                    Object::Integer(rect[0]),
+                    Object::Integer(rect[1]),
+                    Object::Integer(rect[2]),
+                    Object::Integer(rect[1]),
+                    Object::Integer(rect[2]),
+                    Object::Integer(rect[3]),
+                    Object::Integer(rect[0]),
+                    Object::Integer(rect[3]),
+                ]),
+            );
+            annot.set("Contents", Object::string_literal("keep-contents"));
+            self.push_annot(page_index, annot);
+        }
+
         fn save(&mut self, path: &Path) {
             self.doc.save(path).expect("write link fixture");
         }
@@ -752,6 +866,11 @@ mod tests {
         dest_page_index: Option<u32>,
         contents: Option<String>,
         has_annots_key: bool,
+        has_border: bool,
+        has_h: bool,
+        has_f: bool,
+        has_ap: bool,
+        has_quad_points: bool,
     }
 
     fn as_name(obj: &Object) -> Option<String> {
@@ -872,6 +991,11 @@ mod tests {
                     dest_page_index,
                     contents,
                     has_annots_key,
+                    has_border: annot.get(b"Border").is_ok(),
+                    has_h: annot.get(b"H").is_ok(),
+                    has_f: annot.get(b"F").is_ok(),
+                    has_ap: annot.get(b"AP").is_ok(),
+                    has_quad_points: annot.get(b"QuadPoints").is_ok(),
                 })
             })
             .collect()
@@ -1266,5 +1390,181 @@ mod tests {
                 .map(|a| (&a.subtype, &a.contents))
                 .collect::<Vec<_>>()
         );
+    }
+
+    // --- H1 oversize -------------------------------------------------------
+
+    #[test]
+    fn list_oversize_file_is_app_error() {
+        let scratch = Scratch::new("h1");
+        let path = scratch.file("huge.pdf");
+        let f = std::fs::File::create(&path).unwrap();
+        f.set_len(MAX_LINK_BYTES + 1).unwrap();
+        drop(f);
+
+        let err = list_link_annots(&path).expect_err(
+            "H1: list_link_annots on set_len(MAX_LINK_BYTES+1) must be AppError, not Ok([])",
+        );
+        assert_actionable(&err, "H1");
+    }
+
+    // --- H2-list count cap -------------------------------------------------
+
+    #[test]
+    fn list_over_max_links_is_app_error() {
+        let scratch = Scratch::new("h2-list");
+        let src = scratch.file("many.pdf");
+        let mut pdf = PdfFix::new(1, 0, None);
+        pdf.add_n_uri_links(0, MAX_LINKS + 1, "https://example.com/cap");
+        pdf.save(&src);
+
+        match list_link_annots(&src) {
+            Ok(listed) => panic!(
+                "H2-list: 5,001 supported URI /Link annots must be Err, not Ok of length {}",
+                listed.len()
+            ),
+            Err(err) => assert_actionable(&err, "H2-list"),
+        }
+    }
+
+    // --- H2-save incomplete empty must not wipe ----------------------------
+
+    #[test]
+    fn incomplete_empty_session_does_not_rewrite_supported_links() {
+        assert!(
+            !should_rewrite_supported_links(false, 0, true),
+            "H2-save: incomplete hydrate + empty session must not rewrite dest supported links"
+        );
+        assert!(
+            should_rewrite_supported_links(true, 0, true),
+            "H2-save: complete hydrate + empty session must still rewrite (L7 delete-all)"
+        );
+    }
+
+    #[test]
+    fn incomplete_empty_session_does_not_wipe_dest_supported_links() {
+        let scratch = Scratch::new("h2-save");
+        let dest = scratch.file("dest.pdf");
+        let mut pdf = PdfFix::new(1, 0, None);
+        pdf.add_link_uri(0, URI_RECT_PDF, "https://a.example/");
+        pdf.add_link_uri(0, GOTO_RECT_PDF, "https://b.example/");
+        pdf.add_link_uri(0, HIGHLIGHT_RECT_PDF, "https://c.example/");
+        pdf.save(&dest);
+
+        if should_rewrite_supported_links(false, 0, true) {
+            apply_link_annots(&dest, &[]).expect("H2-save: apply empty");
+        }
+
+        let annots = inspect_page_annots(&dest, 1);
+        let uris: Vec<&str> = annots
+            .iter()
+            .filter(|a| a.subtype == "Link" && a.action_s.as_deref() == Some("URI"))
+            .filter_map(|a| a.uri.as_deref())
+            .collect();
+        assert_eq!(
+            uris.len(),
+            3,
+            "H2-save: incomplete hydrate + empty session must not wipe dest supported links; got {uris:?}"
+        );
+        assert!(uris.contains(&"https://a.example/"));
+        assert!(uris.contains(&"https://b.example/"));
+        assert!(uris.contains(&"https://c.example/"));
+    }
+
+    #[test]
+    fn complete_empty_session_still_deletes_dest_supported_links() {
+        assert!(
+            should_rewrite_supported_links(true, 0, true),
+            "H2-save: complete empty must still rewrite (L7)"
+        );
+        let scratch = Scratch::new("h2-save-l7");
+        let dest = scratch.file("dest.pdf");
+        let mut pdf = PdfFix::new(1, 0, None);
+        pdf.add_link_uri(0, URI_RECT_PDF, "https://drop.example/");
+        pdf.save(&dest);
+        apply_link_annots(&dest, &[]).expect("H2-save L7 contrast: apply empty");
+        let annots = inspect_page_annots(&dest, 1);
+        let uris: Vec<&str> = annots
+            .iter()
+            .filter(|a| a.subtype == "Link" && a.action_s.as_deref() == Some("URI"))
+            .filter_map(|a| a.uri.as_deref())
+            .collect();
+        assert!(
+            uris.is_empty(),
+            "H2-save: complete empty session must still delete dest supported links; got {uris:?}"
+        );
+    }
+
+    // --- H3 no-op keeps extra dest keys ------------------------------------
+
+    #[test]
+    fn apply_noop_keeps_extra_link_dict_keys() {
+        let scratch = Scratch::new("h3");
+        let dest = scratch.file("dest.pdf");
+        let mut pdf = PdfFix::new(1, 0, None);
+        pdf.add_link_uri_with_extra_keys(0, URI_RECT_PDF, "https://keep.example/");
+        pdf.save(&dest);
+
+        let links = [SessionLink {
+            page_index: 0,
+            rect: URI_RECT_XYWH,
+            action: LinkAction::Uri {
+                uri: "https://keep.example/".into(),
+            },
+        }];
+        apply_link_annots(&dest, &links).expect("H3: apply_link_annots no-op");
+
+        let annots = inspect_page_annots(&dest, 1);
+        let uri = annots.iter().find(|a| {
+            a.subtype == "Link"
+                && a.action_s.as_deref() == Some("URI")
+                && a.uri.as_deref() == Some("https://keep.example/")
+        });
+        let uri = uri.expect("H3: dest must still have the session URI");
+        assert!(
+            uri.has_border,
+            "H3: dest URI must keep /Border; keys gone after rewrite"
+        );
+        assert!(
+            uri.has_h,
+            "H3: dest URI must keep /H; keys gone after rewrite"
+        );
+        assert!(
+            uri.has_f,
+            "H3: dest URI must keep /F; keys gone after rewrite"
+        );
+        assert!(
+            uri.has_ap,
+            "H3: dest URI must keep /AP; keys gone after rewrite"
+        );
+        assert!(
+            uri.has_quad_points,
+            "H3: dest URI must keep /QuadPoints; keys gone after rewrite"
+        );
+        assert_eq!(
+            uri.contents.as_deref(),
+            Some("keep-contents"),
+            "H3: dest URI must keep /Contents; keys gone after rewrite"
+        );
+    }
+
+    // --- H4 list Err -------------------------------------------------------
+
+    #[test]
+    fn list_missing_path_is_app_error() {
+        let scratch = Scratch::new("h4-missing");
+        let path = scratch.file("missing.pdf");
+        let err =
+            list_link_annots(&path).expect_err("H4: missing path must be AppError, not Ok([])");
+        assert_actionable(&err, "H4 missing path");
+    }
+
+    #[test]
+    fn list_invalid_pdf_is_app_error() {
+        let scratch = Scratch::new("h4-invalid");
+        let path = scratch.file("not.pdf");
+        std::fs::write(&path, b"not a pdf").unwrap();
+        let err = list_link_annots(&path).expect_err("H4: load fail must be AppError, not Ok([])");
+        assert_actionable(&err, "H4 load fail");
     }
 }

--- a/src-tauri/src/pdf_engine/edit_overlay.rs
+++ b/src-tauri/src/pdf_engine/edit_overlay.rs
@@ -4,6 +4,10 @@
 
 use crate::error::AppError;
 use crate::models::{JobHandle, PageGroup};
+use crate::pdf_engine::edit_links::{
+    apply_link_annots, dest_has_supported_links, expected_dest_has_annots, unsafe_uri_error,
+    uri_is_allowed, LinkAction, SessionLink,
+};
 use crate::pdf_engine::validate_output::{
     catalog_flags_from_doc, content_digest, validate_staged_pdf, ContentDigest, OutputSnapshot,
     PageSnapshot,
@@ -196,6 +200,24 @@ pub enum EditObjectIn {
         #[serde(default, rename = "objectRotate")]
         object_rotate: f64,
     },
+    Link {
+        #[serde(rename = "pageIndex")]
+        page_index: u32,
+        rect: PdfRectIn,
+        action: LinkActionIn,
+    },
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(tag = "type", rename_all = "camelCase")]
+pub enum LinkActionIn {
+    Uri {
+        uri: String,
+    },
+    Goto {
+        #[serde(rename = "destPageIndex")]
+        dest_page_index: u32,
+    },
 }
 
 impl EditObjectIn {
@@ -212,11 +234,13 @@ impl EditObjectIn {
             | Self::Text { page_index, .. }
             | Self::Image { page_index, .. }
             | Self::Line { page_index, .. }
-            | Self::Ink { page_index, .. } => *page_index,
+            | Self::Ink { page_index, .. }
+            | Self::Link { page_index, .. } => *page_index,
         }
     }
     fn opacity(&self) -> f64 {
         let o = match self {
+            Self::Link { .. } => return 1.0,
             Self::Rect { opacity, .. }
             | Self::Ellipse { opacity, .. }
             | Self::Triangle { opacity, .. }
@@ -235,6 +259,7 @@ impl EditObjectIn {
 
     fn object_rotate(&self) -> f64 {
         match self {
+            Self::Link { .. } => 0.0,
             Self::Rect { object_rotate, .. }
             | Self::Ellipse { object_rotate, .. }
             | Self::Triangle { object_rotate, .. }
@@ -287,7 +312,8 @@ impl EditObjectIn {
             | Self::Bubble { rect, .. }
             | Self::Arrow { rect, .. }
             | Self::Text { rect, .. }
-            | Self::Image { rect, .. } => pdf_rect_to_overlay(rect, vis, page_rot),
+            | Self::Image { rect, .. }
+            | Self::Link { rect, .. } => pdf_rect_to_overlay(rect, vis, page_rot),
         }
     }
 }
@@ -754,7 +780,7 @@ fn validate_doc(doc: &EditDocumentIn) -> Result<(), AppError> {
         return Err(AppError::new(
             "NO_EDITS",
             "Nothing to save",
-            "Add text, an image or a shape before saving.",
+            "Add text, an image, a shape or a link before saving.",
         ));
     }
     if doc.objects.len() > MAX_OBJECTS {
@@ -779,6 +805,12 @@ fn validate_doc(doc: &EditDocumentIn) -> Result<(), AppError> {
                     "Drawing is too complex",
                     "Use a shorter stroke.",
                 ));
+            }
+            EditObjectIn::Link {
+                action: LinkActionIn::Uri { uri },
+                ..
+            } if !uri_is_allowed(uri) => {
+                return Err(unsafe_uri_error(uri));
             }
             _ => {}
         }
@@ -869,14 +901,11 @@ fn remap_groups_to_visible_box(
         if !copies.contains_key(&g.path) {
             let doc = Document::load(&g.path)
                 .map_err(|e| AppError::engine_failed(format!("Could not read the PDF: {e}")))?;
-            let needs = doc
-                .get_pages()
-                .values()
-                .any(|&id| {
-                    let visible = crop::visible_box(&doc, id);
-                    !boxes_near(crop::align_box(&doc, id), visible)
-                        || !boxes_near(crop::media_box(&doc, id), visible)
-                });
+            let needs = doc.get_pages().values().any(|&id| {
+                let visible = crop::visible_box(&doc, id);
+                !boxes_near(crop::align_box(&doc, id), visible)
+                    || !boxes_near(crop::media_box(&doc, id), visible)
+            });
             if needs {
                 let dest = work.join(format!("src-{n_copies}.pdf"));
                 n_copies += 1;
@@ -1097,6 +1126,64 @@ pub(crate) fn build_edit_overlay_args(
     Ok(args)
 }
 
+fn session_links_from_doc(doc: &EditDocumentIn) -> Vec<SessionLink> {
+    doc.objects
+        .iter()
+        .filter_map(|o| match o {
+            EditObjectIn::Link {
+                page_index,
+                rect,
+                action,
+            } => Some(SessionLink {
+                page_index: *page_index,
+                rect: [rect.x, rect.y, rect.w, rect.h],
+                action: match action {
+                    LinkActionIn::Uri { uri } => LinkAction::Uri { uri: uri.clone() },
+                    LinkActionIn::Goto { dest_page_index } => LinkAction::GoTo {
+                        dest_page_index: *dest_page_index,
+                    },
+                },
+            }),
+            _ => None,
+        })
+        .collect()
+}
+
+/// Link-only save: assemble to dest without `--empty` and without overlay paint.
+fn assemble_to_tmp<F>(
+    groups: &[PageGroup],
+    page_counts: &[u32],
+    tmp: &Path,
+    tmp_str: &str,
+    run: &mut F,
+) -> Result<(), AppError>
+where
+    F: FnMut(&[String]) -> Result<(), AppError>,
+{
+    if groups.is_empty() {
+        return Err(AppError::new("NO_PAGES", "No pages", "Add a PDF first."));
+    }
+    let identity = groups.len() == 1 && super::spec_is_full_range(&groups[0].pages, page_counts[0]);
+    if identity {
+        std::fs::copy(&groups[0].path, tmp)
+            .map_err(|e| AppError::io("Could not prepare the output file.", e))?;
+        return Ok(());
+    }
+    let mut args = vec![
+        groups[0].path.clone(),
+        "--pages".into(),
+        ".".into(),
+        groups[0].pages.clone(),
+    ];
+    for g in &groups[1..] {
+        args.push(g.path.clone());
+        args.push(g.pages.clone());
+    }
+    args.push("--".into());
+    args.push(tmp_str.to_string());
+    run(&args)
+}
+
 /// Build the overlay and run qpdf via `run`. Used by tests (system/`"qpdf"`).
 pub(crate) fn export_edit_pdf_with_runner<F>(
     groups: &[PageGroup],
@@ -1159,19 +1246,38 @@ where
         let font_bytes = std::fs::read(font_path)
             .map_err(|e| AppError::io("Could not read the editor font.", e))?;
         let font = FontInfo::parse(font_bytes)?;
-        write_overlay_pdf(&overlay_str, &geoms, document, &font, cancel)?;
-        let (mapped, restore_boxes) = remap_groups_to_visible_box(groups, work)?;
-        let args = build_edit_overlay_args(&mapped, &counts, &overlay_str, &tmp_str)?;
-        run(&args)?;
-        if restore_boxes {
-            restore_dest_page_boxes(&tmp, &geoms)?;
-            // lopdf xref can look damaged; qpdf rewrite before the atomic replace.
-            let cleaned = work.join("dest-boxes.pdf");
+        let links = session_links_from_doc(document);
+        let has_paint = document
+            .objects
+            .iter()
+            .any(|o| !matches!(o, EditObjectIn::Link { .. }));
+        if has_paint {
+            write_overlay_pdf(&overlay_str, &geoms, document, &font, cancel)?;
+            let (mapped, restore_boxes) = remap_groups_to_visible_box(groups, work)?;
+            let args = build_edit_overlay_args(&mapped, &counts, &overlay_str, &tmp_str)?;
+            run(&args)?;
+            if restore_boxes {
+                restore_dest_page_boxes(&tmp, &geoms)?;
+                // lopdf xref can look damaged; qpdf rewrite before the atomic replace.
+                let cleaned = work.join("dest-boxes.pdf");
+                let cleaned_str = cleaned.to_string_lossy().to_string();
+                run(&[tmp_str.clone(), cleaned_str.clone()])?;
+                safe_output::replace_file(&cleaned, &tmp)?;
+            }
+        } else {
+            assemble_to_tmp(groups, &counts, &tmp, &tmp_str, &mut run)?;
+        }
+        let expected_annots = expected_dest_has_annots(&tmp, &links)?;
+        let rewrite_links = !links.is_empty() || dest_has_supported_links(&tmp)?;
+        if rewrite_links {
+            apply_link_annots(&tmp, &links)?;
+            let cleaned = work.join("dest-links.pdf");
             let cleaned_str = cleaned.to_string_lossy().to_string();
             run(&[tmp_str.clone(), cleaned_str.clone()])?;
             safe_output::replace_file(&cleaned, &tmp)?;
         }
-        let snapshot = output_snapshot_from_source(&geoms, Path::new(&groups[0].path))?;
+        let mut snapshot = output_snapshot_from_source(&geoms, Path::new(&groups[0].path))?;
+        snapshot.catalog.annots = expected_annots;
         let vr = validate_staged_pdf(&tmp, &snapshot, cancel, |args| {
             run_qpdf_check_argv(qpdf_check, args, handle)
         })?;
@@ -1493,6 +1599,9 @@ fn write_overlay_pdf(
             if obj.page_index() as usize != pi {
                 continue;
             }
+            if matches!(obj, EditObjectIn::Link { .. }) {
+                continue;
+            }
             let op100 = (obj.opacity() * 100.0).round() as i32;
             content.push_str(&format!("q\n/GS{op100} gs\n"));
             let rotated = push_object_rotate(
@@ -1722,6 +1831,7 @@ fn write_overlay_pdf(
                         content.push_str("S\n");
                     }
                 }
+                EditObjectIn::Link { .. } => {}
             }
             if rotated {
                 content.push_str("Q\n");
@@ -2367,6 +2477,7 @@ mod tests {
         let _ = std::fs::remove_dir_all(&root);
     }
 
+    // L5 keepGreen: hard-linked dest stays OVERWRITE.
     #[test]
     fn export_rejects_hard_linked_destination() {
         let Some(qpdf) = test_qpdf() else {

--- a/src-tauri/src/pdf_engine/edit_overlay.rs
+++ b/src-tauri/src/pdf_engine/edit_overlay.rs
@@ -5,8 +5,9 @@
 use crate::error::AppError;
 use crate::models::{JobHandle, PageGroup};
 use crate::pdf_engine::edit_links::{
-    apply_link_annots, dest_has_supported_links, expected_dest_has_annots, list_link_annots,
-    should_rewrite_supported_links, unsafe_uri_error, uri_is_allowed, LinkAction, SessionLink,
+    apply_link_annots_for_pages, dest_has_supported_links, dest_ranges_to_rewrite,
+    expected_dest_has_annots, list_link_annots, unsafe_uri_error, uri_is_allowed, LinkAction,
+    SessionLink, MAX_LINKS,
 };
 use crate::pdf_engine::validate_output::{
     catalog_flags_from_doc, content_digest, validate_staged_pdf, ContentDigest, OutputSnapshot,
@@ -776,18 +777,27 @@ fn validate_doc(doc: &EditDocumentIn) -> Result<(), AppError> {
             "This edit was created with a newer OffPDF version.",
         ));
     }
-    if doc.objects.is_empty() {
-        return Err(AppError::new(
-            "NO_EDITS",
-            "Nothing to save",
-            "Add text, an image, a shape or a link before saving.",
-        ));
+    let mut paint = 0usize;
+    let mut links = 0usize;
+    for o in &doc.objects {
+        if matches!(o, EditObjectIn::Link { .. }) {
+            links += 1;
+        } else {
+            paint += 1;
+        }
     }
-    if doc.objects.len() > MAX_OBJECTS {
+    if paint > MAX_OBJECTS {
         return Err(AppError::new(
             "TOO_MANY_OBJECTS",
             "Too many objects",
             format!("This edit has more than {MAX_OBJECTS} objects."),
+        ));
+    }
+    if links > MAX_LINKS {
+        return Err(AppError::new(
+            "TOO_MANY_LINKS",
+            "Too many links",
+            format!("This edit has more than {MAX_LINKS} links."),
         ));
     }
     for o in &doc.objects {
@@ -1222,7 +1232,17 @@ where
 {
     let exe = qpdf::resolve_qpdf_standalone();
     export_edit_pdf_with_check_exe(
-        groups, output, document, font_path, work, unique, cancel, &exe, None, true, run,
+        groups,
+        output,
+        document,
+        font_path,
+        work,
+        unique,
+        cancel,
+        &exe,
+        None,
+        &[],
+        run,
     )
     .map(|(paths, _warnings)| paths)
 }
@@ -1238,7 +1258,7 @@ fn export_edit_pdf_with_check_exe<F>(
     cancel: Option<&AtomicBool>,
     qpdf_check: &Path,
     handle: Option<&Arc<JobHandle>>,
-    links_complete: bool,
+    incomplete_source_paths: &[String],
     mut run: F,
 ) -> Result<(Vec<String>, Vec<String>), AppError>
 where
@@ -1291,15 +1311,26 @@ where
             assemble_to_tmp(groups, &counts, &tmp, &tmp_str, &mut run)?;
         }
         let expected_annots = expected_dest_has_annots(&tmp, &links)?;
-        if !links_complete && !links.is_empty() {
+        if !incomplete_source_paths.is_empty() && !links.is_empty() {
             reject_links_on_unlistable_sources(groups, &counts, &links)?;
         }
-        // Skip dest_has load when hydrate was incomplete so a 400 MiB dest
-        // is not opened just to decide. Complete + empty still deletes (L7).
-        let dest_has = links_complete && links.is_empty() && dest_has_supported_links(&tmp)?;
-        let rewrite_links = should_rewrite_supported_links(links_complete, links.len(), dest_has);
+        let group_pairs: Vec<(&str, u32)> = groups
+            .iter()
+            .zip(counts.iter())
+            .map(|(g, &n)| (g.path.as_str(), n))
+            .collect();
+        let incomplete_refs: Vec<&str> =
+            incomplete_source_paths.iter().map(String::as_str).collect();
+        let dest_pages: Vec<u32> = dest_ranges_to_rewrite(&group_pairs, &incomplete_refs)
+            .into_iter()
+            .flatten()
+            .collect();
+        // Skip dest_has load when no complete source remains (e.g. 400 MiB
+        // unlistable file). Complete empty still deletes when dest has links (L7).
+        let rewrite_links = !dest_pages.is_empty()
+            && (!links.is_empty() || dest_has_supported_links(&tmp)?);
         if rewrite_links {
-            apply_link_annots(&tmp, &links)?;
+            apply_link_annots_for_pages(&tmp, &links, &dest_pages)?;
             let cleaned = work.join("dest-links.pdf");
             let cleaned_str = cleaned.to_string_lossy().to_string();
             run(&[tmp_str.clone(), cleaned_str.clone()])?;
@@ -1378,7 +1409,7 @@ pub fn edit_pdf_overlays(
     groups: &[PageGroup],
     output: &str,
     document: &EditDocumentIn,
-    links_complete: bool,
+    incomplete_source_paths: &[String],
 ) -> Result<(Vec<String>, Vec<String>), AppError> {
     if groups.is_empty() {
         return Err(AppError::new("NO_PAGES", "No pages", "Add a PDF first."));
@@ -1417,7 +1448,7 @@ pub fn edit_pdf_overlays(
             Some(&handle.cancelled),
             &qpdf_exe,
             Some(handle),
-            links_complete,
+            incomplete_source_paths,
             |args| run_qpdf(app, handle, job_id, args, "Saving", None),
         )
     })();
@@ -2018,13 +2049,104 @@ mod tests {
         }
     }
 
+    fn sample_link_obj() -> EditObjectIn {
+        EditObjectIn::Link {
+            page_index: 0,
+            rect: PdfRectIn {
+                x: 10.0,
+                y: 20.0,
+                w: 80.0,
+                h: 40.0,
+            },
+            action: LinkActionIn::Uri {
+                uri: "https://example.com/h8".into(),
+            },
+        }
+    }
+
+    fn sample_rect_obj() -> EditObjectIn {
+        EditObjectIn::Rect {
+            page_index: 0,
+            rect: PdfRectIn {
+                x: 10.0,
+                y: 20.0,
+                w: 80.0,
+                h: 40.0,
+            },
+            fill: None,
+            stroke: None,
+            stroke_width: None,
+            opacity: None,
+            object_rotate: 0.0,
+        }
+    }
+
     #[test]
-    fn validate_rejects_empty() {
+    fn validate_allows_empty() {
         let d = EditDocumentIn {
             version: 1,
             objects: vec![],
         };
-        assert!(validate_doc(&d).is_err());
+        match validate_doc(&d) {
+            Ok(()) => {}
+            Err(err) => panic!("H6-doc: validate_doc([]) must be Ok, not {}", err.code),
+        }
+    }
+
+    #[test]
+    fn validate_allows_501_links() {
+        let d = EditDocumentIn {
+            version: 1,
+            objects: (0..501).map(|_| sample_link_obj()).collect(),
+        };
+        match validate_doc(&d) {
+            Ok(()) => {}
+            Err(err) => panic!(
+                "H8-links: 501 Link objects must pass validate_doc, not {}",
+                err.code
+            ),
+        }
+    }
+
+    #[test]
+    fn validate_rejects_501_paint() {
+        let d = EditDocumentIn {
+            version: 1,
+            objects: (0..501).map(|_| sample_rect_obj()).collect(),
+        };
+        let err =
+            validate_doc(&d).expect_err("H8-paint: 501 paint objects must be TOO_MANY_OBJECTS");
+        assert_eq!(
+            err.code, "TOO_MANY_OBJECTS",
+            "H8-paint: 501 paint objects must be TOO_MANY_OBJECTS, not {}",
+            err.code
+        );
+    }
+
+    #[test]
+    fn validate_allows_500_paint_plus_one_link() {
+        let mut objects: Vec<EditObjectIn> = (0..500).map(|_| sample_rect_obj()).collect();
+        objects.push(sample_link_obj());
+        let d = EditDocumentIn {
+            version: 1,
+            objects,
+        };
+        match validate_doc(&d) {
+            Ok(()) => {}
+            Err(err) => panic!("H8-mix: 500 paint + 1 link must be Ok, not {}", err.code),
+        }
+    }
+
+    #[test]
+    fn validate_allows_5000_links() {
+        let d = EditDocumentIn {
+            version: 1,
+            objects: (0..5000).map(|_| sample_link_obj()).collect(),
+        };
+        match validate_doc(&d) {
+            Ok(()) => {}
+            Err(err) => panic!("H8-mix: 5,000 links must be Ok, not {}", err.code),
+        }
     }
 
     #[test]

--- a/src-tauri/src/pdf_engine/edit_overlay.rs
+++ b/src-tauri/src/pdf_engine/edit_overlay.rs
@@ -5,8 +5,8 @@
 use crate::error::AppError;
 use crate::models::{JobHandle, PageGroup};
 use crate::pdf_engine::edit_links::{
-    apply_link_annots, dest_has_supported_links, expected_dest_has_annots, unsafe_uri_error,
-    uri_is_allowed, LinkAction, SessionLink,
+    apply_link_annots, dest_has_supported_links, expected_dest_has_annots, list_link_annots,
+    should_rewrite_supported_links, unsafe_uri_error, uri_is_allowed, LinkAction, SessionLink,
 };
 use crate::pdf_engine::validate_output::{
     catalog_flags_from_doc, content_digest, validate_staged_pdf, ContentDigest, OutputSnapshot,
@@ -1126,6 +1126,28 @@ pub(crate) fn build_edit_overlay_args(
     Ok(args)
 }
 
+/// When hydrate failed for a source, a session `kind: "link"` on that file's
+/// dest pages must return the same list `AppError` instead of rewriting.
+fn reject_links_on_unlistable_sources(
+    groups: &[PageGroup],
+    counts: &[u32],
+    links: &[SessionLink],
+) -> Result<(), AppError> {
+    let mut dest_base = 0u32;
+    for (g, &n) in groups.iter().zip(counts.iter()) {
+        let end = dest_base.saturating_add(n);
+        let has = links
+            .iter()
+            .any(|l| l.page_index >= dest_base && l.page_index < end);
+        dest_base = end;
+        if !has {
+            continue;
+        }
+        list_link_annots(Path::new(&g.path))?;
+    }
+    Ok(())
+}
+
 fn session_links_from_doc(doc: &EditDocumentIn) -> Vec<SessionLink> {
     doc.objects
         .iter()
@@ -1200,7 +1222,7 @@ where
 {
     let exe = qpdf::resolve_qpdf_standalone();
     export_edit_pdf_with_check_exe(
-        groups, output, document, font_path, work, unique, cancel, &exe, None, run,
+        groups, output, document, font_path, work, unique, cancel, &exe, None, true, run,
     )
     .map(|(paths, _warnings)| paths)
 }
@@ -1216,6 +1238,7 @@ fn export_edit_pdf_with_check_exe<F>(
     cancel: Option<&AtomicBool>,
     qpdf_check: &Path,
     handle: Option<&Arc<JobHandle>>,
+    links_complete: bool,
     mut run: F,
 ) -> Result<(Vec<String>, Vec<String>), AppError>
 where
@@ -1268,7 +1291,13 @@ where
             assemble_to_tmp(groups, &counts, &tmp, &tmp_str, &mut run)?;
         }
         let expected_annots = expected_dest_has_annots(&tmp, &links)?;
-        let rewrite_links = !links.is_empty() || dest_has_supported_links(&tmp)?;
+        if !links_complete && !links.is_empty() {
+            reject_links_on_unlistable_sources(groups, &counts, &links)?;
+        }
+        // Skip dest_has load when hydrate was incomplete so a 400 MiB dest
+        // is not opened just to decide. Complete + empty still deletes (L7).
+        let dest_has = links_complete && links.is_empty() && dest_has_supported_links(&tmp)?;
+        let rewrite_links = should_rewrite_supported_links(links_complete, links.len(), dest_has);
         if rewrite_links {
             apply_link_annots(&tmp, &links)?;
             let cleaned = work.join("dest-links.pdf");
@@ -1349,6 +1378,7 @@ pub fn edit_pdf_overlays(
     groups: &[PageGroup],
     output: &str,
     document: &EditDocumentIn,
+    links_complete: bool,
 ) -> Result<(Vec<String>, Vec<String>), AppError> {
     if groups.is_empty() {
         return Err(AppError::new("NO_PAGES", "No pages", "Add a PDF first."));
@@ -1387,6 +1417,7 @@ pub fn edit_pdf_overlays(
             Some(&handle.cancelled),
             &qpdf_exe,
             Some(handle),
+            links_complete,
             |args| run_qpdf(app, handle, job_id, args, "Saving", None),
         )
     })();

--- a/src-tauri/src/pdf_engine/edit_overlay_integ.rs
+++ b/src-tauri/src/pdf_engine/edit_overlay_integ.rs
@@ -584,6 +584,7 @@ fn write_tiny_png(path: &Path, w: u32, h: u32) {
         .unwrap();
 }
 
+// L4 keepGreen: overlay-only stamp save keeps catalog keys.
 #[test]
 fn integ_catalog_survives_and_original_stream_stays() {
     let Some(fx) = Harness::new("catalog") else {

--- a/src-tauri/src/pdf_engine/mod.rs
+++ b/src-tauri/src/pdf_engine/mod.rs
@@ -9,6 +9,7 @@ pub mod blank;
 pub mod compress;
 pub mod crop;
 pub mod edit_image;
+pub mod edit_links;
 pub mod edit_overlay;
 #[cfg(test)]
 mod edit_overlay_integ;

--- a/src/components/pdf/editor/EditorOverlay.tsx
+++ b/src/components/pdf/editor/EditorOverlay.tsx
@@ -51,7 +51,8 @@ export type EditorTool =
   | "arrow"
   | "line"
   | "ink"
-  | "image";
+  | "image"
+  | "link";
 
 type Handle = ResizeHandle;
 
@@ -81,6 +82,7 @@ type DragMode =
   | { kind: "marquee"; startCss: { x: number; y: number }; additive: boolean }
   | { kind: "create-shape"; shape: ClosedShapeKind; startCss: { x: number; y: number }; lock1to1: boolean }
   | { kind: "create-text"; startCss: { x: number; y: number } }
+  | { kind: "create-link"; startCss: { x: number; y: number } }
   | { kind: "create-line"; startCss: { x: number; y: number } }
   | { kind: "create-ink"; points: { x: number; y: number }[] };
 
@@ -117,6 +119,7 @@ export function EditorOverlay({
   onUpdateRotate,
   onCreateShape,
   onCreateText,
+  onCreateLink,
   onCreateLine,
   onCreateInk,
   onRequestImage,
@@ -139,6 +142,7 @@ export function EditorOverlay({
   onUpdateRotate: (id: string, deg: number) => void;
   onCreateShape: (kind: ClosedShapeKind, rect: PdfRect, keepAspect?: boolean) => void;
   onCreateText: (rect: PdfRect) => void;
+  onCreateLink: (rect: PdfRect) => void;
   onCreateLine: (a: Point, b: Point) => void;
   onCreateInk: (points: Point[]) => void;
   onRequestImage: (atCss: { x: number; y: number }) => void;
@@ -199,6 +203,9 @@ export function EditorOverlay({
       setDraft({ kind: "shape", shape: shapeKind, start: local, cur: local });
     } else if (tool === "text") {
       dragRef.current = { kind: "create-text", startCss: local };
+      setDraft({ kind: "box", start: local, cur: local });
+    } else if (tool === "link") {
+      dragRef.current = { kind: "create-link", startCss: local };
       setDraft({ kind: "box", start: local, cur: local });
     } else if (tool === "line") {
       dragRef.current = { kind: "create-line", startCss: local };
@@ -316,7 +323,7 @@ export function EditorOverlay({
       }
       return;
     }
-    if (drag.kind === "create-text" || drag.kind === "marquee") {
+    if (drag.kind === "create-text" || drag.kind === "create-link" || drag.kind === "marquee") {
       setDraft({ kind: "box", start: drag.startCss, cur: local });
       return;
     }
@@ -399,7 +406,7 @@ export function EditorOverlay({
       }
       return;
     }
-    if (drag.kind === "create-shape" || drag.kind === "create-text") {
+    if (drag.kind === "create-shape" || drag.kind === "create-text" || drag.kind === "create-link") {
       const lock1to1 = drag.kind === "create-shape" && (drag.lock1to1 || e.shiftKey);
       const box = lock1to1 ? constrainCssBox1to1(drag.startCss, local) : cssBoxFromPoints(drag.startCss, local);
       setDraft(null);
@@ -415,6 +422,7 @@ export function EditorOverlay({
         : box;
       const pdf = viewportRectFromCss(fallback, mapping);
       if (drag.kind === "create-text") onCreateText(pdf);
+      else if (drag.kind === "create-link") onCreateLink(pdf);
       else onCreateShape(drag.shape, pdf, drag.lock1to1 || undefined);
       return;
     }
@@ -714,6 +722,20 @@ function ObjectShape({
           onPointerDown={interactive ? (e) => onPointerDownObject(e, obj) : undefined}
         />
       )}
+      {obj.kind === "link" && (
+        <g style={{ cursor: moveCursor }} onPointerDown={interactive ? (e) => onPointerDownObject(e, obj) : undefined}>
+          <rect
+            x={css.x}
+            y={css.y}
+            width={Math.max(css.w, 1)}
+            height={Math.max(css.h, 1)}
+            fill="transparent"
+            stroke="#2563eb"
+            strokeWidth={1.5}
+            strokeDasharray="5 4"
+          />
+        </g>
+      )}
       </g>
       {selected && (
         <rect
@@ -728,7 +750,7 @@ function ObjectShape({
           pointerEvents="none"
         />
       )}
-      {selected && selectedCount === 1 && !obj.locked && (
+      {selected && selectedCount === 1 && !obj.locked && obj.kind !== "link" && (
         <>
           <line
             x1={mid.x}

--- a/src/components/pdf/editor/ObjectInspector.tsx
+++ b/src/components/pdf/editor/ObjectInspector.tsx
@@ -19,6 +19,7 @@ export function ObjectInspector({
   picking,
   layerIndex,
   layerCount,
+  pageCount,
   onChange,
   onPickFromPage,
   onReorder,
@@ -28,6 +29,8 @@ export function ObjectInspector({
   /** 1-based, back = 1, front = layerCount */
   layerIndex: number;
   layerCount: number;
+  /** Assembled page count (GoTo dest picker). */
+  pageCount?: number;
   onChange: (patch: Partial<EditObject>) => void;
   onPickFromPage?: (target: ColorPickTarget) => void;
   onReorder?: (dir: LayerDir) => void;
@@ -41,6 +44,68 @@ export function ObjectInspector({
 
   return (
     <div className="pdf-editor__inspector">
+      {obj.kind === "link" && (
+        <>
+          <div className="pdf-editor__icon-row" role="group" aria-label="Link type">
+            <button
+              type="button"
+              className={`btn btn--sm ${obj.action.type === "uri" ? "btn--primary" : "btn--ghost"}`}
+              onClick={() =>
+                onChange({
+                  action: {
+                    type: "uri",
+                    uri: obj.action.type === "uri" ? obj.action.uri : "https://",
+                  },
+                } as Partial<EditObject>)
+              }
+            >
+              URL
+            </button>
+            <button
+              type="button"
+              className={`btn btn--sm ${obj.action.type === "goto" ? "btn--primary" : "btn--ghost"}`}
+              onClick={() =>
+                onChange({
+                  action: {
+                    type: "goto",
+                    destPageIndex: obj.action.type === "goto" ? obj.action.destPageIndex : 0,
+                  },
+                } as Partial<EditObject>)
+              }
+            >
+              Page
+            </button>
+          </div>
+          {obj.action.type === "uri" && (
+            <>
+              <label className="field__label">Address</label>
+              <input
+                className="pdf-editor__inspector-text"
+                type="text"
+                spellCheck={false}
+                value={obj.action.uri}
+                onChange={(e) =>
+                  onChange({ action: { type: "uri", uri: e.target.value } } as Partial<EditObject>)
+                }
+              />
+            </>
+          )}
+          {obj.action.type === "goto" && (
+            <DraftNumber
+              label="Dest page"
+              value={obj.action.destPageIndex + 1}
+              min={1}
+              max={Math.max(1, pageCount ?? obj.action.destPageIndex + 1)}
+              onCommit={(n) =>
+                onChange({
+                  action: { type: "goto", destPageIndex: n - 1 },
+                } as Partial<EditObject>)
+              }
+            />
+          )}
+        </>
+      )}
+
       {obj.kind === "text" && (
         <>
           <label className="field__label">Text</label>
@@ -185,38 +250,42 @@ export function ObjectInspector({
         </div>
       )}
 
-      <DraftNumber
-        label="Rotation"
-        value={obj.objectRotate ?? 0}
-        min={-180}
-        max={180}
-        suffix="°"
-        onCommit={(n) => onChange({ objectRotate: n })}
-      />
-
-      <label className="field__label">Opacity</label>
-      <div className="pdf-editor__opacity">
-        <input
-          type="range"
-          min={0.1}
-          max={1}
-          step={0.05}
-          value={opacity}
-          aria-label="Opacity"
-          onChange={(e) => onChange({ opacity: Number(e.target.value) } as Partial<EditObject>)}
-        />
+      {obj.kind !== "link" && (
         <DraftNumber
-          label="Opacity percent"
-          hideLabel
-          value={Math.round(opacity * 100)}
-          min={10}
-          max={100}
-          suffix="%"
-          onCommit={(n) => onChange({ opacity: n / 100 } as Partial<EditObject>)}
+          label="Rotation"
+          value={obj.objectRotate ?? 0}
+          min={-180}
+          max={180}
+          suffix="°"
+          onCommit={(n) => onChange({ objectRotate: n })}
         />
-      </div>
+      )}
 
-      {onReorder && layerCount > 0 && (
+      {obj.kind !== "link" && <label className="field__label">Opacity</label>}
+      {obj.kind !== "link" && (
+        <div className="pdf-editor__opacity">
+          <input
+            type="range"
+            min={0.1}
+            max={1}
+            step={0.05}
+            value={opacity}
+            aria-label="Opacity"
+            onChange={(e) => onChange({ opacity: Number(e.target.value) } as Partial<EditObject>)}
+          />
+          <DraftNumber
+            label="Opacity percent"
+            hideLabel
+            value={Math.round(opacity * 100)}
+            min={10}
+            max={100}
+            suffix="%"
+            onCommit={(n) => onChange({ opacity: n / 100 } as Partial<EditObject>)}
+          />
+        </div>
+      )}
+
+      {onReorder && layerCount > 0 && obj.kind !== "link" && (
         <div className="pdf-editor__layer">
           <label className="field__label">Layer</label>
           <div className="muted" style={{ fontSize: 12 }}>

--- a/src/components/pdf/editor/ObjectList.tsx
+++ b/src/components/pdf/editor/ObjectList.tsx
@@ -18,6 +18,13 @@ function labelFor(obj: EditObject, layer: string): string {
   if (obj.kind === "arrow") return `Arrow · ${page} · ${layer}`;
   if (obj.kind === "line") return `Line · ${page} · ${layer}`;
   if (obj.kind === "ink") return `Drawing · ${page} · ${layer}`;
+  if (obj.kind === "link") {
+    if (obj.action.type === "uri") {
+      const u = obj.action.uri.trim() || "Link";
+      return `Link: ${u.length > 22 ? `${u.slice(0, 22)}…` : u} · ${page}`;
+    }
+    return `Link: page ${obj.action.destPageIndex + 1} · ${page}`;
+  }
   return `${isNearlySquare(obj.rect) ? "Square" : "Rectangle"} · ${page} · ${layer}`;
 }
 

--- a/src/components/pdf/editor/PdfEditorCanvas.tsx
+++ b/src/components/pdf/editor/PdfEditorCanvas.tsx
@@ -50,13 +50,14 @@ function newObjectId(): string {
 const MAIN_TOOLS: {
   id: EditorTool;
   label: string;
-  icon: "mousePointer" | "hand" | "type" | "image" | "pencil";
+  icon: "mousePointer" | "hand" | "type" | "image" | "pencil" | "external";
 }[] = [
   { id: "select", label: "Select", icon: "mousePointer" },
   { id: "hand", label: "Hand", icon: "hand" },
   { id: "text", label: "Text", icon: "type" },
   { id: "image", label: "Image", icon: "image" },
   { id: "ink", label: "Draw", icon: "pencil" },
+  { id: "link", label: "Link", icon: "external" },
 ];
 
 function isTextEntryTarget(t: EventTarget | null): boolean {
@@ -443,7 +444,7 @@ export function PdfEditorCanvas({
           <Icon name="clipboard" size={15} />
         </Button>
         <span className="pdf-editor__sep" />
-        {MAIN_TOOLS.filter((t) => t.id !== "ink").map((t) => (
+        {MAIN_TOOLS.filter((t) => t.id !== "ink" && t.id !== "link").map((t) => (
           <Button
             key={t.id}
             size="sm"
@@ -481,6 +482,16 @@ export function PdfEditorCanvas({
           onClick={() => setTool("ink")}
         >
           <Icon name="pencil" size={16} />
+        </Button>
+        <Button
+          size="sm"
+          variant={tool === "link" ? "primary" : "ghost"}
+          title="Link — draw a hotspot (does not open the address)"
+          aria-label="Link"
+          aria-pressed={tool === "link"}
+          onClick={() => setTool("link")}
+        >
+          <Icon name="external" size={16} />
         </Button>
         <span className="pdf-editor__sep" />
         <Button size="sm" variant="ghost" onClick={() => setZoomSafe((z) => z - STEP)} title="Zoom out" aria-label="Zoom out">
@@ -522,6 +533,7 @@ export function PdfEditorCanvas({
             <ObjectInspector
               obj={selected}
               picking={colorPick}
+              pageCount={pageCount}
               layerIndex={pageObjects.findIndex((object) => object.id === selected.id) + 1}
               layerCount={pageObjects.length}
               onChange={(patch) => {
@@ -600,6 +612,10 @@ export function PdfEditorCanvas({
                   }}
                   onCreateText={(rect) => {
                     session.addText(pageIndex, rect);
+                    setTool("select");
+                  }}
+                  onCreateLink={(rect) => {
+                    session.addLink(pageIndex, rect);
                     setTool("select");
                   }}
                   onCreateLine={(a, b) => {

--- a/src/components/pdf/editor/useEditSession.ts
+++ b/src/components/pdf/editor/useEditSession.ts
@@ -8,6 +8,7 @@ import {
   makeImageObject,
   makeInkObject,
   makeLineObject,
+  makeLinkObject,
   makeRectObject,
   makeTextObject,
   mapPointsToRect,
@@ -15,6 +16,7 @@ import {
   type ClosedShapeKind,
   type EditDocument,
   type EditObject,
+  type LinkAction,
   type ShapeStyle,
   type LayerDir,
   type PdfRect,
@@ -91,6 +93,18 @@ export function useEditSession(
   const addInk = useCallback((pageIndex: number, points: Point[]) => {
     if (points.length < 2) return;
     dispatch({ type: "ADD", object: makeInkObject(newId(), pageIndex, points) });
+  }, []);
+
+  const addLink = useCallback((pageIndex: number, rect: PdfRect, action?: LinkAction) => {
+    dispatch({
+      type: "ADD",
+      object: makeLinkObject(newId(), pageIndex, rect, action ?? { type: "uri", uri: "https://" }),
+    });
+  }, []);
+
+  const hydrateObjects = useCallback((objects: EditObject[]) => {
+    if (objects.length === 0) return;
+    dispatch({ type: "HYDRATE", objects });
   }, []);
 
   const addMany = useCallback((objects: EditObject[]) => {
@@ -227,6 +241,8 @@ export function useEditSession(
     addImage,
     addLine,
     addInk,
+    addLink,
+    hydrateObjects,
     addMany,
     updateRect,
     updateObject,

--- a/src/features/edit-pdf/EditPdfPage.tsx
+++ b/src/features/edit-pdf/EditPdfPage.tsx
@@ -33,6 +33,7 @@ import {
   toExportDocument,
 } from "@/lib/editor";
 import { isTauriRuntime } from "@/lib/tauriEnv";
+import { toAppError, type AppError } from "@/lib/types";
 import { Alert } from "@/components/ui/Alert";
 
 const tool = getTool("editPdf");
@@ -66,6 +67,7 @@ export function EditPdfPage() {
   const session = useEditSession(pageKeys);
   const doc = session.document;
   const hydratedUids = useRef(new Set<string>());
+  const hydrateErrors = useRef(new Map<string, AppError>());
   const [hydrateReady, setHydrateReady] = useState(
     () => files.every((f) => (f.pageCount ?? 0) === 0),
   );
@@ -73,7 +75,10 @@ export function EditPdfPage() {
   useEffect(() => {
     const live = new Set(files.map((f) => f.uid));
     for (const uid of [...hydratedUids.current]) {
-      if (!live.has(uid)) hydratedUids.current.delete(uid);
+      if (!live.has(uid)) {
+        hydratedUids.current.delete(uid);
+        hydrateErrors.current.delete(uid);
+      }
     }
     const pending = files.filter((f) => (f.pageCount ?? 0) > 0 && !hydratedUids.current.has(f.uid));
     if (pending.length === 0) {
@@ -84,7 +89,7 @@ export function EditPdfPage() {
     let cancelled = false;
     void (async () => {
       const mapped: import("@/lib/editor").EditObject[] = [];
-      const succeeded: string[] = [];
+      const finished: string[] = [];
       for (const file of pending) {
         try {
           const listed = await listPdfLinks(file.path);
@@ -105,14 +110,19 @@ export function EditPdfPage() {
                 : `link-${file.uid}-${link.pageIndex}-${mapped.length}`;
             mapped.push(makeLinkObject(id, pageIndex, link.rect, action));
           }
-          succeeded.push(file.uid);
-        } catch {
-          continue;
+          hydrateErrors.current.delete(file.uid);
+          finished.push(file.uid);
+        } catch (e) {
+          if (cancelled) return;
+          const err = toAppError(e);
+          hydrateErrors.current.set(file.uid, err);
+          toast({ title: err.title, description: err.message, variant: "error" });
+          finished.push(file.uid);
         }
       }
       if (cancelled) return;
       if (mapped.length > 0) session.hydrateObjects(mapped);
-      for (const uid of succeeded) hydratedUids.current.add(uid);
+      for (const uid of finished) hydratedUids.current.add(uid);
       setHydrateReady(pending.every((f) => hydratedUids.current.has(f.uid)));
     })();
     return () => {
@@ -168,8 +178,14 @@ export function EditPdfPage() {
     }
     if (!(await disk.ensure(folder, estimateRequiredBytes("editPdf", files.map((f) => f.sizeBytes))))) return;
 
+    const failedLinkErr = sessionLinkErrorOnFailedFile(doc.objects, refs, hydrateErrors.current);
+    if (failedLinkErr) {
+      return toast({ title: failedLinkErr.title, description: failedLinkErr.message, variant: "error" });
+    }
+    const linksComplete = files.every((f) => !hydrateErrors.current.has(f.uid));
+
     await job.run(
-      (id) => editPdfOverlays(id, outputPath, buildGroups(refs), toExportDocument(doc)),
+      (id) => editPdfOverlays(id, outputPath, buildGroups(refs), toExportDocument(doc), linksComplete),
       { tool: "editPdf", label: `Edit PDF · ${doc.objects.length} object${doc.objects.length === 1 ? "" : "s"}` },
     );
   };
@@ -247,4 +263,24 @@ export function EditPdfPage() {
       </Modal>
     </ToolPage>
   );
+}
+
+function fileUidFromPageKey(key: string): string {
+  const hash = key.lastIndexOf("#");
+  return hash >= 0 ? key.slice(0, hash) : key;
+}
+
+function sessionLinkErrorOnFailedFile(
+  objects: { kind: string; pageIndex: number }[],
+  refs: { key: string }[],
+  errors: Map<string, AppError>,
+): AppError | undefined {
+  for (const o of objects) {
+    if (o.kind !== "link") continue;
+    const ref = refs[o.pageIndex];
+    if (!ref) continue;
+    const err = errors.get(fileUidFromPageKey(ref.key));
+    if (err) return err;
+  }
+  return undefined;
 }

--- a/src/features/edit-pdf/EditPdfPage.tsx
+++ b/src/features/edit-pdf/EditPdfPage.tsx
@@ -16,7 +16,7 @@ import {
 } from "@/components/pdf";
 import { useEditSession } from "@/components/pdf/editor";
 import { useJob, JobStatus, useDiskGuard } from "@/components/jobs";
-import { editPdfOverlays } from "@/lib/tauriCommands";
+import { editPdfOverlays, listPdfLinks } from "@/lib/tauriCommands";
 import { getTool } from "@/lib/tools";
 import { estimateRequiredBytes, validateOutputName, joinPath } from "@/lib/validation";
 import { stripExt } from "@/lib/formatBytes";
@@ -24,6 +24,7 @@ import { useSettingsStore } from "@/state/settingsStore";
 import { useWorkspace } from "@/state/workspaceStore";
 import {
   clampPageIndex,
+  makeLinkObject,
   planKeyRebind,
   rebindNeedsConfirm,
   resolveViewPageIndex,
@@ -64,6 +65,60 @@ export function EditPdfPage() {
 
   const session = useEditSession(pageKeys);
   const doc = session.document;
+  const hydratedUids = useRef(new Set<string>());
+  const [hydrateReady, setHydrateReady] = useState(
+    () => files.every((f) => (f.pageCount ?? 0) === 0),
+  );
+
+  useEffect(() => {
+    const live = new Set(files.map((f) => f.uid));
+    for (const uid of [...hydratedUids.current]) {
+      if (!live.has(uid)) hydratedUids.current.delete(uid);
+    }
+    const pending = files.filter((f) => (f.pageCount ?? 0) > 0 && !hydratedUids.current.has(f.uid));
+    if (pending.length === 0) {
+      setHydrateReady(true);
+      return;
+    }
+    setHydrateReady(false);
+    let cancelled = false;
+    void (async () => {
+      const mapped: import("@/lib/editor").EditObject[] = [];
+      const succeeded: string[] = [];
+      for (const file of pending) {
+        try {
+          const listed = await listPdfLinks(file.path);
+          if (cancelled) return;
+          for (const link of listed) {
+            const pageIndex = refs.findIndex((r) => r.key === `${file.uid}#${link.pageIndex + 1}`);
+            if (pageIndex < 0) continue;
+            let action = link.action;
+            if (action.type === "goto") {
+              const destPage = action.destPageIndex;
+              const dest = refs.findIndex((r) => r.key === `${file.uid}#${destPage + 1}`);
+              if (dest < 0) continue;
+              action = { type: "goto", destPageIndex: dest };
+            }
+            const id =
+              typeof crypto !== "undefined" && "randomUUID" in crypto
+                ? crypto.randomUUID()
+                : `link-${file.uid}-${link.pageIndex}-${mapped.length}`;
+            mapped.push(makeLinkObject(id, pageIndex, link.rect, action));
+          }
+          succeeded.push(file.uid);
+        } catch {
+          continue;
+        }
+      }
+      if (cancelled) return;
+      if (mapped.length > 0) session.hydrateObjects(mapped);
+      for (const uid of succeeded) hydratedUids.current.add(uid);
+      setHydrateReady(pending.every((f) => hydratedUids.current.has(f.uid)));
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [files, refs, session.hydrateObjects]);
 
   const first = files[0];
   useEffect(() => {
@@ -102,6 +157,7 @@ export function EditPdfPage() {
 
   const start = async () => {
     if (refs.length === 0) return toast({ title: "Add a PDF first", variant: "error" });
+    if (!hydrateReady) return toast({ title: "Still reading links from the PDF", variant: "error" });
     if (doc.objects.length === 0) return toast({ title: "Add something to the page first", variant: "error" });
     if (!folder) return toast({ title: "Choose an output folder", variant: "error" });
     const nameRes = validateOutputName(name);
@@ -118,7 +174,7 @@ export function EditPdfPage() {
     );
   };
 
-  const canStart = !job.isBusy && inTauri;
+  const canStart = !job.isBusy && inTauri && hydrateReady;
 
   return (
     <ToolPage tool={tool}>

--- a/src/features/edit-pdf/EditPdfPage.tsx
+++ b/src/features/edit-pdf/EditPdfPage.tsx
@@ -24,6 +24,8 @@ import { useSettingsStore } from "@/state/settingsStore";
 import { useWorkspace } from "@/state/workspaceStore";
 import {
   clampPageIndex,
+  emptyObjectsBlockSave,
+  incompleteSourcePaths,
   makeLinkObject,
   planKeyRebind,
   rebindNeedsConfirm,
@@ -68,6 +70,7 @@ export function EditPdfPage() {
   const doc = session.document;
   const hydratedUids = useRef(new Set<string>());
   const hydrateErrors = useRef(new Map<string, AppError>());
+  const hydratedLinkUids = useRef(new Set<string>());
   const [hydrateReady, setHydrateReady] = useState(
     () => files.every((f) => (f.pageCount ?? 0) === 0),
   );
@@ -78,6 +81,7 @@ export function EditPdfPage() {
       if (!live.has(uid)) {
         hydratedUids.current.delete(uid);
         hydrateErrors.current.delete(uid);
+        hydratedLinkUids.current.delete(uid);
       }
     }
     const pending = files.filter((f) => (f.pageCount ?? 0) > 0 && !hydratedUids.current.has(f.uid));
@@ -109,6 +113,11 @@ export function EditPdfPage() {
                 ? crypto.randomUUID()
                 : `link-${file.uid}-${link.pageIndex}-${mapped.length}`;
             mapped.push(makeLinkObject(id, pageIndex, link.rect, action));
+          }
+          if (listed.length > 0) {
+            hydratedLinkUids.current.add(file.uid);
+          } else {
+            hydratedLinkUids.current.delete(file.uid);
           }
           hydrateErrors.current.delete(file.uid);
           finished.push(file.uid);
@@ -168,7 +177,14 @@ export function EditPdfPage() {
   const start = async () => {
     if (refs.length === 0) return toast({ title: "Add a PDF first", variant: "error" });
     if (!hydrateReady) return toast({ title: "Still reading links from the PDF", variant: "error" });
-    if (doc.objects.length === 0) return toast({ title: "Add something to the page first", variant: "error" });
+    if (
+      emptyObjectsBlockSave({
+        objectCount: doc.objects.length,
+        hadHydratedLinks: hydratedLinkUids.current.size > 0,
+      })
+    ) {
+      return toast({ title: "Add something to the page first", variant: "error" });
+    }
     if (!folder) return toast({ title: "Choose an output folder", variant: "error" });
     const nameRes = validateOutputName(name);
     if (!nameRes.ok) return toast({ title: "Invalid file name", description: nameRes.error, variant: "error" });
@@ -182,10 +198,20 @@ export function EditPdfPage() {
     if (failedLinkErr) {
       return toast({ title: failedLinkErr.title, description: failedLinkErr.message, variant: "error" });
     }
-    const linksComplete = files.every((f) => !hydrateErrors.current.has(f.uid));
+    const incompletePaths = incompleteSourcePaths(
+      files,
+      new Set(hydrateErrors.current.keys()),
+    );
 
     await job.run(
-      (id) => editPdfOverlays(id, outputPath, buildGroups(refs), toExportDocument(doc), linksComplete),
+      (id) =>
+        editPdfOverlays(
+          id,
+          outputPath,
+          buildGroups(refs),
+          toExportDocument(doc),
+          incompletePaths,
+        ),
       { tool: "editPdf", label: `Edit PDF · ${doc.objects.length} object${doc.objects.length === 1 ? "" : "s"}` },
     );
   };

--- a/src/lib/editor/EDIT_MODEL.md
+++ b/src/lib/editor/EDIT_MODEL.md
@@ -15,6 +15,9 @@ invent a second coordinate system.
 ## What this module is not
 
 - It does **not** edit existing page content operators.
+- **Links** (`kind: "link"`) are PDF `/Annots`, not overlay stamps. They use
+  the same unrotated `EditObject.rect` space. Overlay paint skips them; Save
+  rewrites dest `/Link` dictionaries after `qpdf --overlay`.
 - It does **not** hold source PDF bytes. Paths and per-page bytes stay in the
   render layer (same pattern as `pagePdf`).
 - Image **bytes** are not stored in the document — only a local path (plus a

--- a/src/lib/editor/editReducer.ts
+++ b/src/lib/editor/editReducer.ts
@@ -16,7 +16,7 @@ import {
   type PdfRect,
   type Point,
 } from "./types";
-import { cloneDocument } from "./serialize";
+import { cloneDocument, cloneObject } from "./serialize";
 
 export const MAX_HISTORY = 100;
 
@@ -45,6 +45,7 @@ export type EditAction =
   | { type: "REDO" }
   | { type: "REPLACE"; document: EditDocument }
   | { type: "REBIND"; present: EditDocument; past: EditDocument[]; future: EditDocument[] }
+  | { type: "HYDRATE"; objects: EditObject[] }
   | { type: "RESET" };
 
 /** Later objects on the same page paint in front. `null` if the move is a no-op. */
@@ -243,6 +244,24 @@ export function editReducer(state: HistoryState, action: EditAction): HistorySta
         gestureCommitted: false,
       };
 
+    case "HYDRATE": {
+      if (action.objects.length === 0) return state;
+      const added = action.objects.map((o) => {
+        const next = { ...o, rect: normalizePdfRect(o.rect) } as EditObject;
+        return next;
+      });
+      const inject = (doc: EditDocument): EditDocument => ({
+        ...doc,
+        objects: [...doc.objects, ...added.map(cloneObject)],
+      });
+      return {
+        ...state,
+        present: inject(state.present),
+        past: state.past.map(inject),
+        future: state.future.map(inject),
+      };
+    }
+
     case "RESET":
       return createHistoryState();
 
@@ -374,5 +393,20 @@ export function makeInkObject(
     stroke: "#111827",
     strokeWidth: 2.5,
     opacity: 1,
+  };
+}
+
+export function makeLinkObject(
+  id: string,
+  pageIndex: number,
+  rect: PdfRect,
+  action: import("./types").LinkAction,
+): import("./types").LinkObject {
+  return {
+    id,
+    kind: "link",
+    pageIndex,
+    rect: normalizePdfRect(rect),
+    action,
   };
 }

--- a/src/lib/editor/index.ts
+++ b/src/lib/editor/index.ts
@@ -109,3 +109,9 @@ export { moveSelectedRects, selectedIdsOnPage } from "./moveSelection";
 export { shouldShowEditCanvas } from "./editVisibility";
 export type { EditCanvasVisibility } from "./editVisibility";
 export { clampPageIndex } from "./pageIndex";
+export {
+  emptyObjectsBlockSave,
+  incompleteSourceIds,
+  incompleteSourcePaths,
+  shouldRewriteSourceLinks,
+} from "./linkSavePolicy";

--- a/src/lib/editor/index.ts
+++ b/src/lib/editor/index.ts
@@ -20,6 +20,8 @@ export type {
   ImageObject,
   LineObject,
   InkObject,
+  LinkAction,
+  LinkObject,
   TextAlign,
   EditObject,
   EditDocument,
@@ -66,6 +68,7 @@ export {
   makeImageObject,
   makeLineObject,
   makeInkObject,
+  makeLinkObject,
 } from "./editReducer";
 
 export type { ResizeHandle } from "./resizeRect";

--- a/src/lib/editor/linkObject.test.ts
+++ b/src/lib/editor/linkObject.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from "vitest";
+import { makeLinkObject } from "./editReducer";
+
+describe("makeLinkObject", () => {
+  it("stores unrotated rect and uri / goto action", () => {
+    const uri = makeLinkObject("l1", 0, { x: 100, y: 200, w: 80, h: 40 }, {
+      type: "uri",
+      uri: "https://example.com",
+    });
+    expect(uri.kind).toBe("link");
+    expect(uri.pageIndex).toBe(0);
+    expect(uri.rect).toEqual({ x: 100, y: 200, w: 80, h: 40 });
+    expect(uri.action).toEqual({ type: "uri", uri: "https://example.com" });
+
+    const goto = makeLinkObject("l2", 1, { x: 10, y: 20, w: 30, h: 40 }, {
+      type: "goto",
+      destPageIndex: 2,
+    });
+    expect(goto.kind).toBe("link");
+    expect(goto.action).toEqual({ type: "goto", destPageIndex: 2 });
+    expect(JSON.parse(JSON.stringify(goto)).kind).toBe("link");
+  });
+});

--- a/src/lib/editor/linkSavePolicy.test.ts
+++ b/src/lib/editor/linkSavePolicy.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest";
+import {
+  emptyObjectsBlockSave,
+  incompleteSourceIds,
+  incompleteSourcePaths,
+  shouldRewriteSourceLinks,
+} from "./linkSavePolicy";
+
+describe("emptyObjectsBlockSave", () => {
+  it("H6-ui: empty objects + hadHydratedLinks does not block Save", () => {
+    expect(
+      emptyObjectsBlockSave({ objectCount: 0, hadHydratedLinks: true }),
+    ).toBe(false);
+  });
+
+  it("H6-ui: empty objects + never hydrated still blocks", () => {
+    expect(
+      emptyObjectsBlockSave({ objectCount: 0, hadHydratedLinks: false }),
+    ).toBe(true);
+  });
+});
+
+describe("shouldRewriteSourceLinks", () => {
+  it("H7-ui: per-failed-source paths; mixed-source edit is allowed", () => {
+    const files = [
+      { uid: "A", path: "/a.pdf" },
+      { uid: "B", path: "/b.pdf" },
+    ];
+    const failed = new Set(["A"]);
+    const incomplete = incompleteSourceIds(
+      files.map((f) => f.uid),
+      failed,
+    );
+    expect(incomplete).toEqual(["A"]);
+    expect(incompleteSourcePaths(files, failed)).toEqual(["/a.pdf"]);
+    expect(
+      shouldRewriteSourceLinks({
+        sourceId: "B",
+        incompleteSourceIds: incomplete,
+      }),
+    ).toBe(true);
+    expect(
+      shouldRewriteSourceLinks({
+        sourceId: "A",
+        incompleteSourceIds: incomplete,
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/lib/editor/linkSavePolicy.ts
+++ b/src/lib/editor/linkSavePolicy.ts
@@ -1,0 +1,34 @@
+/**
+ * Edit-PDF Save gates for link hydrate / multi-source rewrite (issue #35 r2).
+ *
+ * Empty objects block Save only when this session never hydrated a link.
+ * Incomplete hydrate is per failed source — complete sources still rewrite.
+ */
+
+export function emptyObjectsBlockSave(args: {
+  objectCount: number;
+  hadHydratedLinks: boolean;
+}): boolean {
+  return args.objectCount === 0 && !args.hadHydratedLinks;
+}
+
+export function incompleteSourceIds(
+  sourceIds: readonly string[],
+  failedIds: ReadonlySet<string>,
+): string[] {
+  return sourceIds.filter((id) => failedIds.has(id));
+}
+
+export function incompleteSourcePaths(
+  files: readonly { uid: string; path: string }[],
+  failedUids: ReadonlySet<string>,
+): string[] {
+  return files.filter((f) => failedUids.has(f.uid)).map((f) => f.path);
+}
+
+export function shouldRewriteSourceLinks(args: {
+  sourceId: string;
+  incompleteSourceIds: readonly string[];
+}): boolean {
+  return !args.incompleteSourceIds.includes(args.sourceId);
+}

--- a/src/lib/editor/remapPages.ts
+++ b/src/lib/editor/remapPages.ts
@@ -31,6 +31,15 @@ export function remapEditDocument(
     }
     const clone = cloneObject(o);
     clone.pageIndex = next;
+    if (clone.kind === "link" && clone.action.type === "goto") {
+      const destKey = oldKeys[clone.action.destPageIndex];
+      const nextDest = destKey === undefined ? undefined : indexOf.get(destKey);
+      if (nextDest === undefined) {
+        droppedIds.push(o.id);
+        continue;
+      }
+      clone.action = { type: "goto", destPageIndex: nextDest };
+    }
     objects.push(clone);
   }
   const keep = new Set(objects.map((o) => o.id));

--- a/src/lib/editor/types.ts
+++ b/src/lib/editor/types.ts
@@ -55,7 +55,8 @@ export type EditObjectKind =
   | "text"
   | "image"
   | "line"
-  | "ink";
+  | "ink"
+  | "link";
 
 export type ClosedShapeKind =
   | "rect"
@@ -187,6 +188,16 @@ export interface InkObject extends EditObjectBase {
   opacity?: number;
 }
 
+/** URI or in-document GoTo. Same unrotated `rect` space as overlay stamps. */
+export type LinkAction =
+  | { type: "uri"; uri: string }
+  | { type: "goto"; destPageIndex: number };
+
+export interface LinkObject extends EditObjectBase {
+  kind: "link";
+  action: LinkAction;
+}
+
 export type EditObject =
   | RectObject
   | RoundRectObject
@@ -199,7 +210,8 @@ export type EditObject =
   | TextObject
   | ImageObject
   | LineObject
-  | InkObject;
+  | InkObject
+  | LinkObject;
 
 /** Bounds of a line segment. */
 export function lineBounds(x1: number, y1: number, x2: number, y2: number): PdfRect {

--- a/src/lib/tauriCommands.ts
+++ b/src/lib/tauriCommands.ts
@@ -291,9 +291,15 @@ export function editPdfOverlays(
   outputPath: string,
   groups: PageGroup[],
   document: EditDocument,
-  linksComplete = true,
+  incompleteSourcePaths: string[] = [],
 ): Promise<JobResult> {
-  return invoke<JobResult>("edit_pdf_overlays", { jobId, outputPath, groups, document, linksComplete });
+  return invoke<JobResult>("edit_pdf_overlays", {
+    jobId,
+    outputPath,
+    groups,
+    document,
+    incompleteSourcePaths,
+  });
 }
 
 export function stampPdf(

--- a/src/lib/tauriCommands.ts
+++ b/src/lib/tauriCommands.ts
@@ -291,8 +291,9 @@ export function editPdfOverlays(
   outputPath: string,
   groups: PageGroup[],
   document: EditDocument,
+  linksComplete = true,
 ): Promise<JobResult> {
-  return invoke<JobResult>("edit_pdf_overlays", { jobId, outputPath, groups, document });
+  return invoke<JobResult>("edit_pdf_overlays", { jobId, outputPath, groups, document, linksComplete });
 }
 
 export function stampPdf(

--- a/src/lib/tauriCommands.ts
+++ b/src/lib/tauriCommands.ts
@@ -18,6 +18,7 @@ import type {
   JobResult,
   JobUpdate,
   OutlineItem,
+  PdfLink,
   PageGroup,
   PagePick,
   RenderedThumb,
@@ -251,6 +252,11 @@ export function pagePdf(inputPath: string, page: number): Promise<string | null>
 /** A PDF's bookmarks/outline (flattened); empty if none or file too large. */
 export function pdfOutline(inputPath: string): Promise<OutlineItem[]> {
   return invoke<OutlineItem[]>("pdf_outline", { inputPath });
+}
+
+/** Supported URI / GoTo `/Link` annots. Paths in; never fetches a URI. */
+export function listPdfLinks(inputPath: string): Promise<PdfLink[]> {
+  return invoke<PdfLink[]>("list_pdf_links", { inputPath });
 }
 
 /** Visually compare two pages; returns a diff-overlay image + changed percent. */

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -38,6 +38,17 @@ export interface OutlineItem {
   level: number;
 }
 
+/** One supported `/Link` from `list_pdf_links` (unrotated `[x,y,w,h]` as a box). */
+export type PdfLinkAction =
+  | { type: "uri"; uri: string }
+  | { type: "goto"; destPageIndex: number };
+
+export interface PdfLink {
+  pageIndex: number;
+  rect: { x: number; y: number; w: number; h: number };
+  action: PdfLinkAction;
+}
+
 /** Bounded editor image preview (Rust `ImagePreview`). */
 export interface ImagePreview {
   dataUrl: string;


### PR DESCRIPTION
## Summary

Implements [#35](https://github.com/McanKul/offpdf/issues/35): manage standard URI and in-document GoTo **link annotations** on Edit PDF.

This is a **different job** from [#54](https://github.com/McanKul/offpdf/pull/54) (#34 publish gate). Save still uses that gate, so this branch is stacked on it.

**Depends on #54.** Please merge #54 first. After that this PR rebases to link-only commits. Merging this before #54 would also land the validation gate.

### In scope

- Detect existing `/Link` annotations whose action is allowlisted URI (`https` / `http` / `mailto`) or in-document GoTo
- Show those hotspots on the canvas (dashed rect, same Crop/Rotate space as stamps)
- Create, edit, and remove supported links
- Leave JS / Launch / file / remote-GoTo and unrelated annotations unchanged
- Save writes real `/Annots`, then the #34 `qpdf --check` + snapshot gate
- Original file is never overwritten

### Out of scope

- Automatically opening links from the editor
- Comments / highlights (#8), AcroForm (#9), redaction (#10), editing existing page text (#11)
- Combined “label text + destination” create tool (follow-up)

## Why

Overlay stamps are not PDF links. Viewers need `/Subtype /Link` + `/A`.

## Validation

- [x] `npm run typecheck`
- [x] `npm test` (180)
- [x] `cargo test --manifest-path src-tauri/Cargo.toml --lib` (120)
- [x] Manual Edit PDF with local QA PDFs (URI, GoTo, mixed, rotate+crop, clean)

## Privacy Checklist

- [x] This keeps OffPDF usable offline.
- [x] This does not upload, log, or transmit user files. URIs are not fetched.
- [x] New dependencies or bundled binaries have compatible licenses.