### PR TITLE
chore(release): prepare OffPDF v0.3.1

### DIFF
--- a/.github/release-notes/v0.3.1.md
+++ b/.github/release-notes/v0.3.1.md
@@ -1,0 +1,24 @@
+OffPDF v0.3.1 makes the visual PDF editor safer and adds editable links while
+keeping every operation local to your computer.
+
+Highlights:
+
+- Add, edit, and remove web, email, and in-document links in Edit PDF.
+- Validate edited output before replacing the destination file; a failed check
+  leaves both the original and any existing destination untouched.
+- Reject inconsistent HEIC/HEIF decoded buffers instead of risking a native
+  crash on unusual phone photos.
+- Expand regression fixtures and automated coverage for PDF geometry, file-type
+  detection, runtime detection, and accessible form controls.
+
+Thanks to @nonamexishere, @alexsmolya, and @YatoVoid for contributing to this
+release.
+
+Packages:
+
+- Signed and notarized DMG for Apple Silicon Macs
+- Windows x64 NSIS installer, available from GitHub Releases with its SHA-256
+  checksum and clearly marked as unsigned while Authenticode signing is pending
+
+See [CHANGELOG.md](https://github.com/McanKul/offpdf/blob/v0.3.1/CHANGELOG.md)
+for full details.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable project changes should be documented here.
 
 ## Unreleased
 
+## 0.3.1 - 2026-08-28
+
 ### Added
 
 - Edit PDF: staged output is checked with `qpdf --check` and reopened for page boxes, per-page content identity, and catalog data before the destination file is replaced. A failed check leaves the original and any existing destination untouched. `qpdf --check` warnings (exit 3) still publish and appear on the completed job update.
@@ -12,6 +14,10 @@ All notable project changes should be documented here.
 ### Fixed
 
 - HEIC/HEIF import refuses to copy pixels when the decoded plane size does not match the image handle, so a tiled or rotated phone photo cannot walk off the buffer. Invalid files still return an in-app error.
+
+### Contributors
+
+- Thank you to @nonamexishere, @alexsmolya, and @YatoVoid for their contributions to this release.
 
 ## 0.3.0 - 2026-08-15
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -5,14 +5,14 @@ reliable local processing, clear packaging, and a contributor-friendly project.
 
 ## Current release
 
-- **v0.2.2** is the latest published release. Its historical Windows package is
-  unsigned and remains available through GitHub Releases.
+- **v0.3.0** is the latest published release. Its Windows package is unsigned
+  and remains available through GitHub Releases.
 - The Apple Silicon macOS build is signed and notarized. It bundles qpdf,
   Poppler, and Tesseract; LibreOffice remains optional for Office and PDF/A work.
 
 ## Next release
 
-- **v0.3.0** is being prepared for distribution through GitHub Releases and
+- **v0.3.1** is being prepared for distribution through GitHub Releases and
   [offpdf.com](https://offpdf.com).
 - The Windows x64 installer bundles qpdf, Poppler, Tesseract, and LibreOffice so
   the supported workflows run offline. It is distributed through GitHub Releases

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "offpdf",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "offpdf",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
         "@tauri-apps/api": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "offpdf",
   "private": true,
-  "version": "0.3.0",
+  "version": "0.3.1",
   "type": "module",
   "description": "Free, open-source, offline-first desktop PDF utility.",
   "license": "MIT",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2846,7 +2846,7 @@ dependencies = [
 
 [[package]]
 name = "offpdf"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "fs2",
  "heif-rs",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "offpdf"
-version = "0.3.0"
+version = "0.3.1"
 description = "Free, open-source, offline-first desktop PDF utility."
 authors = ["OffPDF contributors"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "OffPDF",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "identifier": "app.offpdf.desktop",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
Prepares the v0.3.1 maintenance release.

- bumps desktop, npm, and Rust package versions
- moves the current Unreleased changes into v0.3.1
- adds GitHub release notes and updates the roadmap release status

Validated locally:
- npm run build
- npm test (256 tests)
- cargo test --manifest-path src-tauri/Cargo.toml --lib (151 tests)