### PR TITLE
docs: describe Edit PDF annotations and forms

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,29 @@ service in the middle.
 | Compare PDFs | | |
 | Remove blank pages | | |
 
+### Edit PDF capabilities
+
+The Edit PDF workspace adds text, images, shapes, links, and freehand drawing as
+new content. It can also create PDF notes, highlights, underlines, strikeouts,
+and ink annotations while preserving existing annotations.
+
+For interactive PDFs, OffPDF can fill existing AcroForm text fields (including
+multiline fields), checkboxes, radio buttons, combo boxes, and list boxes. Form
+fields stay interactive by default.
+
+The two flattening options have different scopes:
+
+- **Flatten form fields** turns supported form widgets into page content while
+  leaving other annotations interactive.
+- **Flatten annotations** turns all remaining annotations into non-interactive
+  page content. When a PDF contains form fields, OffPDF requires form fields to
+  be flattened as part of this operation.
+
+Current limits: XFA forms are not supported; only the first PDF's AcroForm can
+be filled when several files are combined; and Edit PDF does not rewrite text
+or images already embedded in a source page. New text and images are added as
+overlays instead.
+
 ## Downloads
 
 | Platform | Package | Status |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -5,15 +5,13 @@ reliable local processing, clear packaging, and a contributor-friendly project.
 
 ## Current release
 
-- **v0.3.0** is the latest published release. Its Windows package is unsigned
+- **v0.3.1** is the latest published release. Its Windows package is unsigned
   and remains available through GitHub Releases.
 - The Apple Silicon macOS build is signed and notarized. It bundles qpdf,
   Poppler, and Tesseract; LibreOffice remains optional for Office and PDF/A work.
 
-## Next release
+## Distribution
 
-- **v0.3.1** is being prepared for distribution through GitHub Releases and
-  [offpdf.com](https://offpdf.com).
 - The Windows x64 installer bundles qpdf, Poppler, Tesseract, and LibreOffice so
   the supported workflows run offline. It is distributed through GitHub Releases
   with an explicit unsigned warning while Authenticode signing is completed;
@@ -34,7 +32,7 @@ reliable local processing, clear packaging, and a contributor-friendly project.
 - Reduce the Windows package size without weakening offline functionality.
 - Add official Intel Mac and Linux packages.
 - Improve OCR language selection and optional language-pack guidance.
-- Expand editor support for annotations, links, and common form workflows.
+- Harden annotation, link, and AcroForm editing across more real-world PDFs.
 - Improve accessibility across keyboard navigation, focus states, and screen-reader labels.
 
 ## Known limitations
@@ -46,6 +44,14 @@ reliable local processing, clear packaging, and a contributor-friendly project.
 - Lossy compression rasterizes pages. Use text-preserving compression when text
   selection matters.
 - Complex Office conversions are best effort and may not reproduce every layout.
+- Edit PDF supports notes, highlights, underlines, strikeouts, ink annotations,
+  and common AcroForm text, checkbox, radio, combo, and list fields. XFA forms
+  are not supported.
+- In a multi-file Edit PDF job, only the first PDF's AcroForm can be filled.
+  Additional files that contain form fields must be removed from the job.
+- Flatten form fields converts form widgets to page content while preserving
+  other annotations. Flatten annotations converts all remaining annotations to
+  page content and requires form fields to be flattened when they are present.
 - Edit PDF adds new text, images, and shapes as overlays; it does not rewrite
   existing text or images inside the source document.
 - Auto-update is intentionally not enabled.


### PR DESCRIPTION
Closes #71.

## Summary

- document Edit PDF notes, highlights, underlines, strikeouts, and ink annotations
- document supported AcroForm text, checkbox, radio, combo, and list fields
- explain the different scopes of form-field and annotation flattening
- state the current XFA, multi-file form, and source-content editing limits
- update the roadmap to identify v0.3.1 as the current published release

## Why

The public README and roadmap still described Edit PDF as an overlay-only text, image, and shape editor. That no longer reflected the annotation and AcroForm workflows available on the development branch, and the roadmap still presented the already-published v0.3.1 release as upcoming.

## Validation

- [x] `npm run build`
- [x] `npm test` - 30 files and 261 tests passed
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml` - not applicable; documentation only

## Privacy Checklist

- [x] This keeps OffPDF usable offline.
- [x] This does not upload, log, or transmit user files.
- [x] No dependencies or bundled binaries were added.

## AI disclosure

AI assistance was used to cross-check the documentation against the editor types, form controls, flattening implementation, and published release metadata. The wording and limits were then reviewed against the source and verified with the commands above.
