### PR TITLE
fix(windows): clean up qpdf staging files

### DIFF
--- a/scripts/prepare-qpdf-windows.ps1
+++ b/scripts/prepare-qpdf-windows.ps1
@@ -31,35 +31,41 @@ if (-not $Asset) {
 }
 
 $TempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("offpdf-qpdf-" + [guid]::NewGuid())
-New-Item -ItemType Directory -Path $TempRoot | Out-Null
-$ZipPath = Join-Path $TempRoot $Asset.name
+try {
+  New-Item -ItemType Directory -Path $TempRoot | Out-Null
+  $ZipPath = Join-Path $TempRoot $Asset.name
 
-Write-Host "Downloading $($Asset.name)"
-Invoke-WebRequest -Uri $Asset.browser_download_url -OutFile $ZipPath -Headers $Headers
+  Write-Host "Downloading $($Asset.name)"
+  Invoke-WebRequest -Uri $Asset.browser_download_url -OutFile $ZipPath -Headers $Headers
 
-Write-Host "Extracting qpdf"
-Expand-Archive -Path $ZipPath -DestinationPath $TempRoot -Force
+  Write-Host "Extracting qpdf"
+  Expand-Archive -Path $ZipPath -DestinationPath $TempRoot -Force
 
-$QpdfExe = Get-ChildItem -Path $TempRoot -Recurse -Filter "qpdf.exe" |
-  Where-Object { $_.FullName -match "[\\/]bin[\\/]qpdf\.exe$" } |
-  Select-Object -First 1
+  $QpdfExe = Get-ChildItem -Path $TempRoot -Recurse -Filter "qpdf.exe" |
+    Where-Object { $_.FullName -match "[\\/]bin[\\/]qpdf\.exe$" } |
+    Select-Object -First 1
 
-if (-not $QpdfExe) {
-  throw "Could not find qpdf.exe in extracted archive."
-}
-
-$QpdfBin = $QpdfExe.Directory.FullName
-Write-Host "Copying qpdf runtime from $QpdfBin to $OutDir"
-
-Copy-Item -Path (Join-Path $QpdfBin "qpdf.exe") -Destination $OutDir -Force
-Get-ChildItem -Path $QpdfBin -Filter "*.dll" | Copy-Item -Destination $OutDir -Force
-
-foreach ($Runtime in @("msvcp140.dll", "vcruntime140.dll", "vcruntime140_1.dll")) {
-  $RuntimeSource = Join-Path $QpdfBin $Runtime
-  if (-not (Test-Path $RuntimeSource)) {
-    throw "Could not find required Windows runtime in the qpdf archive: $Runtime"
+  if (-not $QpdfExe) {
+    throw "Could not find qpdf.exe in extracted archive."
   }
-  Copy-Item -Path $RuntimeSource -Destination $RuntimeOutDir -Force
+
+  $QpdfBin = $QpdfExe.Directory.FullName
+  Write-Host "Copying qpdf runtime from $QpdfBin to $OutDir"
+
+  Copy-Item -Path (Join-Path $QpdfBin "qpdf.exe") -Destination $OutDir -Force
+  Get-ChildItem -Path $QpdfBin -Filter "*.dll" | Copy-Item -Destination $OutDir -Force
+
+  foreach ($Runtime in @("msvcp140.dll", "vcruntime140.dll", "vcruntime140_1.dll")) {
+    $RuntimeSource = Join-Path $QpdfBin $Runtime
+    if (-not (Test-Path $RuntimeSource)) {
+      throw "Could not find required Windows runtime in the qpdf archive: $Runtime"
+    }
+    Copy-Item -Path $RuntimeSource -Destination $RuntimeOutDir -Force
+  }
+} finally {
+  if (Test-Path -LiteralPath $TempRoot) {
+    Remove-Item -LiteralPath $TempRoot -Recurse -Force
+  }
 }
 
 Write-Host "Bundled files:"


### PR DESCRIPTION
## Summary

- Wrap Windows qpdf staging in `try`/`finally` and remove its temporary directory on success or failure.
- Preserve copied qpdf binaries, Visual C++ runtime files, existing output, and version handling.

## Why

Closes #38. Downloaded archives and extracted files currently remain in `offpdf-qpdf-*` directories after the script exits.

## Validation

- [x] `npm run build`
- [x] `npm test` (261 tests across 30 files)
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml` (not run; no Rust changes)
- PowerShell syntax parsing passed.
- An isolated local verification harness reproduced the staging leak before the change with a simulated download failure.
- After the change, simulated download and extraction failures both preserved the original error and left no staging directories.
- A real qpdf 12.4.1 download/extraction completed with no staging directories left behind. The staged executable reported version 12.4.1, and all three required runtime DLL copies matched their source hashes.
- The local harness and downloaded artifacts are not included in this PR.

## Privacy Checklist

- [x] This keeps OffPDF usable offline.
- [x] This does not upload, log, or transmit user files.
- [x] New dependencies or bundled binaries have compatible licenses (none added).