### PR TITLE
test(home): add tool search matching helper

### DIFF
--- a/src/lib/toolSearch.test.ts
+++ b/src/lib/toolSearch.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import type { ToolMeta } from "./tools";
+import { searchTools } from "./toolSearch";
+
+const tools: ToolMeta[] = [
+  {
+    id: "merge",
+    name: "Merge PDFs",
+    description: "Combine several PDFs into one file.",
+    longDescription: "Join documents into one PDF.",
+    icon: "merge",
+    path: "/tools/merge",
+    category: "Organize",
+    aliases: ["join documents"],
+  },
+  {
+    id: "compress",
+    name: "Compress PDF",
+    description: "Reduce the file size for smaller storage.",
+    longDescription: "Optimize a PDF for smaller storage.",
+    icon: "compress",
+    path: "/tools/compress",
+    category: "Optimize & secure",
+  },
+  {
+    id: "officeToPdf",
+    name: "Office / HTML to PDF",
+    description: "Convert office documents and HTML files to PDF.",
+    longDescription: "Convert documents locally.",
+    icon: "fileText",
+    path: "/tools/office-to-pdf",
+    category: "Convert",
+    aliases: ["docx", "word files"],
+  },
+];
+
+describe("searchTools", () => {
+  it("returns all tools for an empty query", () => {
+    expect(searchTools(tools, "")).toEqual(tools);
+  });
+
+  it("returns category tools for a whitespace-only query", () => {
+    expect(searchTools(tools, "   ", "Convert")).toEqual([tools[2]]);
+  });
+
+  it("matches case-insensitively", () => {
+    expect(searchTools(tools, "cOmPrEsS")).toEqual([tools[1]]);
+  });
+
+  it("matches partial names", () => {
+    expect(searchTools(tools, "merge pdf")).toEqual([tools[0]]);
+  });
+
+  it("matches descriptions", () => {
+    expect(searchTools(tools, "smaller storage")).toEqual([tools[1]]);
+  });
+
+  it("matches category text", () => {
+    expect(searchTools(tools, "secure")).toEqual([tools[1]]);
+  });
+
+  it("matches explicit aliases", () => {
+    expect(searchTools(tools, "DOCX")).toEqual([tools[2]]);
+  });
+
+  it("applies category and query filters together", () => {
+    expect(searchTools(tools, "pdf", "Convert")).toEqual([tools[2]]);
+    expect(searchTools(tools, "pdf", "Organize")).toEqual([tools[0]]);
+  });
+
+  it("returns no results when nothing matches", () => {
+    expect(searchTools(tools, "spreadsheet")).toEqual([]);
+  });
+
+  it("preserves input order", () => {
+    const reversed = [tools[2], tools[0], tools[1]];
+    expect(searchTools(reversed, "pdf")).toEqual(reversed);
+  });
+
+  it("does not mutate the source array or tool objects", () => {
+    const source = tools.map((tool) => ({ ...tool, aliases: tool.aliases ? [...tool.aliases] : undefined }));
+    const sourceSnapshot = structuredClone(source);
+
+    const result = searchTools(source, "pdf");
+
+    expect(result).not.toBe(source);
+    expect(source).toEqual(sourceSnapshot);
+    expect(result[0]).toBe(source[0]);
+  });
+});

--- a/src/lib/toolSearch.ts
+++ b/src/lib/toolSearch.ts
@@ -1,0 +1,18 @@
+import type { ToolCategory, ToolMeta } from "./tools";
+
+/** Returns tools matching the query and optional category without mutating the registry. */
+export function searchTools(
+  tools: readonly ToolMeta[],
+  query: string,
+  category: ToolCategory | "All" = "All",
+): ToolMeta[] {
+  const normalizedQuery = query.trim().toLowerCase();
+
+  return tools.filter((tool) => {
+    if (category !== "All" && tool.category !== category) return false;
+    if (normalizedQuery === "") return true;
+
+    const searchableFields = [tool.name, tool.description, tool.category, ...(tool.aliases ?? [])];
+    return searchableFields.some((field) => field.toLowerCase().includes(normalizedQuery));
+  });
+}

--- a/src/lib/tools.ts
+++ b/src/lib/tools.ts
@@ -14,6 +14,7 @@ export interface ToolMeta {
   icon: IconName;
   path: string;
   category: ToolCategory;
+  aliases?: readonly string[];
 }
 
 export const TOOLS: ToolMeta[] = [
@@ -96,6 +97,7 @@ export const TOOLS: ToolMeta[] = [
     icon: "fileText",
     path: "/tools/edit-pdf",
     category: "Organize",
+    aliases: ["annotations"],
   },
   {
     id: "poster",
@@ -136,6 +138,7 @@ export const TOOLS: ToolMeta[] = [
     icon: "fileText",
     path: "/tools/office-to-pdf",
     category: "Convert",
+    aliases: ["docx", "xlsx", "pptx"],
   },
   {
     id: "pdfToOffice",
@@ -146,6 +149,7 @@ export const TOOLS: ToolMeta[] = [
     icon: "fileText",
     path: "/tools/pdf-to-office",
     category: "Convert",
+    aliases: ["docx", "pptx"],
   },
   {
     id: "images",
@@ -176,6 +180,7 @@ export const TOOLS: ToolMeta[] = [
     icon: "badge",
     path: "/tools/pdfa",
     category: "Convert",
+    aliases: ["archival"],
   },
   {
     id: "compress",


### PR DESCRIPTION
## Summary
- add a pure tool-search matching helper for name, description, category, and explicit aliases
- preserve category filtering, input ordering, and registry immutability
- add focused Vitest coverage for matching and filtering behavior

## Scope
- HomePage.tsx and the search UI are intentionally not changed.

## Verification
- npm.cmd test -- src/lib/toolSearch.test.ts
- npm.cmd test
- npm.cmd run build

Closes #92