### PR TITLE
ci(release): check version metadata consistency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Check release version metadata
+        run: npm run check:versions
+
       - name: Build frontend
         run: npm run build
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,11 +39,18 @@ npm run tauri:dev
 Useful checks:
 
 ```bash
+npm run check:versions
 npm run build
 npm test
 cargo check --manifest-path src-tauri/Cargo.toml
 cargo test --manifest-path src-tauri/Cargo.toml
 ```
+
+`npm run check:versions` verifies that the release version matches in
+`package.json`, both root version fields in `package-lock.json`,
+`src-tauri/Cargo.toml`, the OffPDF entry in `src-tauri/Cargo.lock`, and
+`src-tauri/tauri.conf.json`. Update these together when changing the version.
+CI runs this check on pull requests and reports mismatched files and values.
 
 ## Engineering guidelines
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "@types/react": "^18.3.12",
         "@types/react-dom": "^18.3.1",
         "@vitejs/plugin-react": "^4.3.4",
+        "smol-toml": "^1.8.0",
         "typescript": "^5.6.3",
         "vite": "^5.4.11",
         "vitest": "^2.1.8"
@@ -2400,6 +2401,19 @@
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/smol-toml": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.8.0.tgz",
+      "integrity": "sha512-kCZr2V3ch9i00x8zXRhjUNVcjG9ijES5dDudkXvUVCT5QlJNQWElSJdZqyPemffHoLNUYwOcou0Fy+ojN0uHSQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/cyyynthia"
+      }
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "build": "tsc --noEmit && vite build",
     "preview": "vite preview",
     "typecheck": "tsc --noEmit",
+    "check:versions": "node scripts/check-versions.mjs",
     "test": "vitest run",
     "test:watch": "vitest",
     "tauri": "tauri",
@@ -31,6 +32,7 @@
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
     "@vitejs/plugin-react": "^4.3.4",
+    "smol-toml": "^1.8.0",
     "typescript": "^5.6.3",
     "vite": "^5.4.11",
     "vitest": "^2.1.8"

--- a/scripts/check-versions.mjs
+++ b/scripts/check-versions.mjs
@@ -1,0 +1,35 @@
+import { readFileSync } from "node:fs";
+import { parse as parseToml } from "smol-toml";
+
+function read(file, parse = JSON.parse) {
+  try {
+    return parse(readFileSync(file, "utf8"));
+  } catch (error) {
+    throw new Error(`Could not read ${file}: ${error.message}`);
+  }
+}
+
+try {
+  const pkg = read("package.json");
+  const npmLock = read("package-lock.json");
+  const cargo = read("src-tauri/Cargo.toml", parseToml);
+  const cargoLock = read("src-tauri/Cargo.lock", parseToml);
+  const tauri = read("src-tauri/tauri.conf.json");
+  const versions = [
+    ["package.json version", pkg?.version],
+    ["package-lock.json version", npmLock?.version],
+    ['package-lock.json packages[""].version', npmLock?.packages?.[""]?.version],
+    ["src-tauri/Cargo.toml package.version", cargo.package?.version],
+    ["src-tauri/Cargo.lock offpdf.version", cargoLock.package?.find((entry) => entry.name === "offpdf")?.version],
+    ["src-tauri/tauri.conf.json version", tauri?.version],
+  ];
+  const expected = pkg?.version;
+  if (versions.some(([, version]) => typeof version !== "string" || !version.trim() || version !== expected)) {
+    const details = versions.map(([field, version]) => `${field}: ${version === undefined ? "<missing>" : JSON.stringify(version)}`);
+    throw new Error(`Release version metadata is inconsistent:\n${details.join("\n")}`);
+  }
+  console.log(`Release version metadata matches: ${expected}`);
+} catch (error) {
+  console.error(error.message);
+  process.exitCode = 1;
+}

--- a/scripts/check-versions.test.mjs
+++ b/scripts/check-versions.test.mjs
@@ -1,0 +1,106 @@
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+const script = fileURLToPath(new URL("./check-versions.mjs", import.meta.url));
+let root;
+
+function run() {
+  return spawnSync(process.execPath, [script], { cwd: root, encoding: "utf8" });
+}
+
+function updateJson(file, update) {
+  const path = join(root, file);
+  const value = JSON.parse(readFileSync(path, "utf8"));
+  update(value);
+  writeFileSync(path, JSON.stringify(value));
+}
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), "offpdf-versions-"));
+  mkdirSync(join(root, "src-tauri"));
+  writeFileSync(join(root, "package.json"), JSON.stringify({ name: "offpdf", version: "0.3.1" }));
+  writeFileSync(join(root, "package-lock.json"), JSON.stringify({
+    version: "0.3.1",
+    packages: { "": { version: "0.3.1" }, "node_modules/example": { version: "9.0.0" } },
+  }));
+  writeFileSync(join(root, "src-tauri/tauri.conf.json"), JSON.stringify({ version: "0.3.1" }));
+  writeFileSync(join(root, "src-tauri/Cargo.toml"), `
+[package]
+name = 'offpdf'
+version = '0.3.1' # release version
+[dependencies]
+example = { version = "9.0.0" }
+`);
+  writeFileSync(join(root, "src-tauri/Cargo.lock"), `
+version = 4
+[[package]]
+name = "example"
+version = "9.0.0"
+[[package]]
+name = "offpdf"
+version = "0.3.1"
+`);
+});
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe("release version check", () => {
+  it("accepts matching metadata without comparing dependency or lockfile format versions", () => {
+    const result = run();
+    expect(result.stderr).toBe("");
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("0.3.1");
+  });
+
+  it.each([
+    "package.json",
+    "package-lock.json",
+    "src-tauri/tauri.conf.json",
+    "src-tauri/Cargo.toml",
+    "src-tauri/Cargo.lock",
+  ])("rejects a mismatched version in %s and reports files and values", (file) => {
+    const path = join(root, file);
+    writeFileSync(path, readFileSync(path, "utf8").replace("0.3.1", "0.3.2"));
+    const result = run();
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("Release version metadata is inconsistent");
+    expect(result.stderr).toContain(file);
+    expect(result.stderr).toContain("0.3.2");
+    expect(result.stderr).toContain("0.3.1");
+  });
+
+  it("checks the npm lockfile root package independently of its top-level version", () => {
+    updateJson("package-lock.json", (lock) => { lock.packages[""].version = "0.3.2"; });
+    const result = run();
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('package-lock.json packages[""].version: "0.3.2"');
+  });
+
+  it("rejects a missing version instead of treating it as a match", () => {
+    updateJson("src-tauri/tauri.conf.json", (config) => { delete config.version; });
+    const result = run();
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("src-tauri/tauri.conf.json version: <missing>");
+  });
+
+  it("requires an OffPDF package entry in the Cargo lockfile", () => {
+    const path = join(root, "src-tauri/Cargo.lock");
+    writeFileSync(path, readFileSync(path, "utf8").replace('name = "offpdf"', 'name = "other"'));
+    const result = run();
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("src-tauri/Cargo.lock offpdf.version: <missing>");
+  });
+
+  it.each(["package.json", "src-tauri/Cargo.toml"])("reports the filename when %s cannot be parsed", (file) => {
+    writeFileSync(join(root, file), "invalid {");
+    const result = run();
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(`Could not read ${file}:`);
+  });
+});


### PR DESCRIPTION
## Summary

- Add `npm run check:versions` to compare release versions in `package.json`, both root version fields in `package-lock.json`, `src-tauri/Cargo.toml`, the OffPDF package in `src-tauri/Cargo.lock`, and `src-tauri/tauri.conf.json`.
- Run the check in pull-request CI and report exact metadata fields and values on mismatch.
- Add 11 CLI regression tests and document the check in the contributor guide.

## Why

Closes #68. The check catches source metadata drift without consulting Git tags or comparing unrelated dependency versions. `smol-toml` is a development-only dependency for parsing Cargo metadata correctly, including comments and quoted strings.

## Validation

- [x] `npm run build`
- [x] `npm test` (283 tests across 32 files)
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml` (not run; no Rust code changes)
- `npm ci` and `npm run check:versions` passed against the current 0.3.1 metadata.
- Regression tests exercise the CLI exit status and diagnostics for mismatches in every metadata file, the nested npm lockfile version, missing versions, a missing OffPDF Cargo entry, and malformed JSON/TOML.
- Existing dependency audit and build-size warnings remain outside this change.

## Privacy Checklist

- [x] This keeps OffPDF usable offline.
- [x] This does not upload, log, or transmit user files.
- [x] New dependencies or bundled binaries have compatible licenses (`smol-toml`: BSD-3-Clause, development-only; no bundled binaries added).