### PR TITLE
feat(desktop): open supported files from the OS into the workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,22 @@ All published binaries are available on the
 See the [code signing policy](./CODE_SIGNING_POLICY.md) for how official release
 artifacts are built, approved, and verified.
 
+## Open With (desktop)
+
+A packaged build registers OffPDF as an **Open With** handler for the same types
+the in-app picker already accepts (PDF, images including HEIC/HEIF, and Office).
+It is not the silent default PDF app (`bundle.fileAssociations` uses
+`rank: Alternate`). Choose OffPDF from Finder, Explorer, or your Linux file
+manager.
+
+Opened files go into the existing workspace. No merge, compress, convert, or
+redact job starts until you pick a tool. If OffPDF is already running, the
+existing window is focused and the files are added there.
+
+Association metadata lives in `src-tauri/tauri.conf.json`. Full Finder/Explorer
+clicks need a packaged build (`npm run tauri:build`) or a local `tauri:dev`
+session plus a manual OS association.
+
 ## Privacy model
 
 - Documents are processed by local binaries on your machine.

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2858,6 +2858,7 @@ dependencies = [
  "tauri-build",
  "tauri-plugin-dialog",
  "tauri-plugin-opener",
+ "tauri-plugin-single-instance",
  "ttf-parser",
 ]
 
@@ -4370,6 +4371,22 @@ dependencies = [
  "thiserror 2.0.18",
  "url",
  "windows",
+ "zbus",
+]
+
+[[package]]
+name = "tauri-plugin-single-instance"
+version = "2.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cd0cb5c412a5071b69bab6a6df1583cbb89460d4a83b6a24769b08d15b6b1e1"
+dependencies = [
+ "serde",
+ "serde_json",
+ "tauri",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "windows-sys 0.60.2",
  "zbus",
 ]
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -44,6 +44,9 @@ image = { version = "0.25", default-features = false, features = [
 # app so users do not need to install a system codec or upload their photos.
 heif-rs = { path = "vendor/heif-rs" }
 
+[target.'cfg(any(target_os = "macos", windows, target_os = "linux"))'.dependencies]
+tauri-plugin-single-instance = "2"
+
 [features]
 # By default Tauri uses custom protocols. Keep network features off.
 default = ["custom-protocol"]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -16,6 +16,7 @@
 //!   - `open_path(path: String) -> Result<(), AppError>`
 //!   - `clear_temp_files() -> Result<u64, AppError>`  (bytes freed)
 //!   - `get_temp_dir() -> Result<String, AppError>`
+//!   - `take_opened_paths() -> Vec<String>`  (OS Open With / argv; paths only)
 //!
 //! PDF operations (`commands::pdf`) — all take a frontend-generated `job_id`
 //! and emit `job:update` events while running:
@@ -34,20 +35,35 @@
 mod commands;
 mod error;
 mod models;
+mod os_open;
 mod pdf_engine;
 mod utils;
 
 use models::JobRegistry;
+use std::sync::Mutex;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
-    tauri::Builder::default()
+    let mut builder = tauri::Builder::default();
+
+    // First plugin: a second launch forwards argv to this process instead of
+    // opening another empty workspace. Local IPC only (named pipe / UDS / D-Bus).
+    #[cfg(any(windows, target_os = "linux", target_os = "macos"))]
+    {
+        builder = builder.plugin(tauri_plugin_single_instance::init(|app, args, _cwd| {
+            os_open::focus_main_window(app);
+            os_open::enqueue_opened_paths(app, os_open::parse_opened_argv(args));
+        }));
+    }
+
+    builder
         // Local file dialogs (open/save). No network.
         .plugin(tauri_plugin_dialog::init())
         // Open a file or folder in the OS default handler. No network.
         .plugin(tauri_plugin_opener::init())
         // Shared, cancellable job registry.
         .manage(JobRegistry::default())
+        .manage(Mutex::new(os_open::OpenedPathQueue::default()))
         .invoke_handler(tauri::generate_handler![
             // files / system
             commands::files::pick_pdf_files,
@@ -61,6 +77,7 @@ pub fn run() {
             commands::files::copy_file,
             commands::files::clear_temp_files,
             commands::files::get_temp_dir,
+            os_open::take_opened_paths,
             // pdf operations
             commands::pdf::merge_pdfs,
             commands::pdf::assemble_pdf,
@@ -107,6 +124,22 @@ pub fn run() {
             commands::render::write_pdf_meta,
             commands::render::export_pdf_text,
         ])
-        .run(tauri::generate_context!())
-        .expect("error while running the OffPDF application");
+        .setup(|app| {
+            os_open::enqueue_cold_start_argv(app.handle());
+            Ok(())
+        })
+        .build(tauri::generate_context!())
+        .expect("error while running the OffPDF application")
+        .run(|app, event| {
+            if let tauri::RunEvent::Opened { urls } = event {
+                let paths = urls
+                    .iter()
+                    .filter_map(|url| os_open::parse_opened_token(url.as_str()))
+                    .collect();
+                os_open::enqueue_opened_paths(app, paths);
+            }
+        });
 }
+
+#[cfg(test)]
+mod os_open_tests;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -131,12 +131,18 @@ pub fn run() {
         .build(tauri::generate_context!())
         .expect("error while running the OffPDF application")
         .run(|app, event| {
-            if let tauri::RunEvent::Opened { urls } = event {
-                let paths = urls
-                    .iter()
-                    .filter_map(|url| os_open::parse_opened_token(url.as_str()))
-                    .collect();
-                os_open::enqueue_opened_paths(app, paths);
+            // Finder delivers Opened only on macOS. Linux/Windows use argv +
+            // single-instance (enqueue_cold_start_argv / plugin callback).
+            match event {
+                #[cfg(target_os = "macos")]
+                tauri::RunEvent::Opened { urls } => {
+                    let paths = urls
+                        .iter()
+                        .filter_map(|url| os_open::parse_opened_token(url.as_str()))
+                        .collect();
+                    os_open::enqueue_opened_paths(app, paths);
+                }
+                _ => {}
             }
         });
 }

--- a/src-tauri/src/os_open.rs
+++ b/src-tauri/src/os_open.rs
@@ -1,0 +1,187 @@
+//! Parse OS-opened file tokens (argv / `file://`) and hand paths to the UI.
+//!
+//! Paths only — this module never reads file bytes.
+
+use std::path::PathBuf;
+use std::sync::Mutex;
+
+use tauri::{AppHandle, Emitter, Manager, State};
+
+/// Event the frontend listens for after it has called [`take_opened_paths`].
+pub const OPENED_PATHS_EVENT: &str = "os-open:paths";
+
+/// Cold-start buffer so Opened/argv paths are not lost before the webview listens.
+#[derive(Default)]
+pub struct OpenedPathQueue {
+    pending: Vec<String>,
+    frontend_ready: bool,
+}
+
+/// Skip argv[0], then map the rest through [`parse_opened_token`].
+pub fn parse_opened_argv(args: impl IntoIterator<Item = impl AsRef<str>>) -> Vec<PathBuf> {
+    let mut iter = args.into_iter();
+    let _argv0 = iter.next();
+    iter.filter_map(|token| parse_opened_token(token.as_ref()))
+        .collect()
+}
+
+/// Accept a raw path or `file://` (percent-decoded). Drop `-flag`s, non-file
+/// URLs, and bare argv[0]-like tokens. Does not read file bytes.
+pub fn parse_opened_token(token: &str) -> Option<PathBuf> {
+    let token = token.trim();
+    if token.is_empty() || token.starts_with('-') {
+        return None;
+    }
+    if let Some(after_scheme) = strip_file_scheme(token) {
+        return file_url_to_path(after_scheme);
+    }
+    if has_non_file_scheme(token) {
+        return None;
+    }
+    if is_bare_argv0_like(token) {
+        return None;
+    }
+    Some(PathBuf::from(token))
+}
+
+/// Windows/Linux cold start: Open With arrives as argv. No-op on macOS
+/// (Finder delivers `RunEvent::Opened` instead).
+pub fn enqueue_cold_start_argv(app: &AppHandle) {
+    #[cfg(any(windows, target_os = "linux"))]
+    {
+        enqueue_opened_paths(app, parse_opened_argv(std::env::args()));
+    }
+    #[cfg(not(any(windows, target_os = "linux")))]
+    let _ = app;
+}
+
+/// Queue paths until the frontend is ready, then emit them. No-op if empty.
+pub fn enqueue_opened_paths(app: &AppHandle, paths: Vec<PathBuf>) {
+    if paths.is_empty() {
+        return;
+    }
+    let strings: Vec<String> = paths
+        .into_iter()
+        .map(|p| p.to_string_lossy().into_owned())
+        .collect();
+    let queue = app.state::<Mutex<OpenedPathQueue>>();
+    let mut guard = match queue.lock() {
+        Ok(g) => g,
+        Err(_) => return,
+    };
+    if guard.frontend_ready {
+        drop(guard);
+        let _ = app.emit(OPENED_PATHS_EVENT, strings);
+    } else {
+        guard.pending.extend(strings);
+    }
+}
+
+/// Focus the existing single window (second-instance / Open With while running).
+pub fn focus_main_window(app: &AppHandle) {
+    if let Some(window) = app.get_webview_window("main") {
+        let _ = window.unminimize();
+        let _ = window.show();
+        let _ = window.set_focus();
+    }
+}
+
+/// Drain queued cold-start paths and mark the frontend ready for live events.
+#[tauri::command]
+pub fn take_opened_paths(queue: State<'_, Mutex<OpenedPathQueue>>) -> Vec<String> {
+    let mut guard = match queue.lock() {
+        Ok(g) => g,
+        Err(poisoned) => poisoned.into_inner(),
+    };
+    guard.frontend_ready = true;
+    std::mem::take(&mut guard.pending)
+}
+
+fn strip_file_scheme(token: &str) -> Option<&str> {
+    if token.len() >= 7 && token[..7].eq_ignore_ascii_case("file://") {
+        Some(&token[7..])
+    } else {
+        None
+    }
+}
+
+fn has_non_file_scheme(token: &str) -> bool {
+    let Some(idx) = token.find("://") else {
+        return false;
+    };
+    let scheme = &token[..idx];
+    !scheme.is_empty()
+        && scheme
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || b == b'+' || b == b'.' || b == b'-')
+}
+
+fn is_bare_argv0_like(token: &str) -> bool {
+    !token.contains('/') && !token.contains('\\') && !token.contains('.')
+}
+
+fn file_url_to_path(after_scheme: &str) -> Option<PathBuf> {
+    let path_part = strip_localhost_host(after_scheme);
+    let decoded = percent_decode(path_part)?;
+    if decoded.is_empty() {
+        return None;
+    }
+    Some(PathBuf::from(windows_drive_path(decoded)))
+}
+
+fn strip_localhost_host(after_scheme: &str) -> &str {
+    const HOST: &str = "localhost";
+    if after_scheme.len() >= HOST.len() && after_scheme[..HOST.len()].eq_ignore_ascii_case(HOST) {
+        let rest = &after_scheme[HOST.len()..];
+        if rest.is_empty() || rest.starts_with('/') {
+            return rest;
+        }
+    }
+    after_scheme
+}
+
+/// `file:///C:/Users/...` → `C:/Users/...` on Windows; unchanged elsewhere.
+fn windows_drive_path(decoded: String) -> String {
+    #[cfg(windows)]
+    {
+        if let Some(trimmed) = decoded.strip_prefix('/') {
+            let bytes = trimmed.as_bytes();
+            if bytes.len() >= 2 && bytes[0].is_ascii_alphabetic() && (bytes[1] == b':' || bytes[1] == b'|')
+            {
+                let mut out = trimmed.to_string();
+                if bytes[1] == b'|' {
+                    out.replace_range(1..2, ":");
+                }
+                return out;
+            }
+        }
+    }
+    decoded
+}
+
+fn percent_decode(input: &str) -> Option<String> {
+    let bytes = input.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'%' && i + 2 < bytes.len() {
+            if let (Some(hi), Some(lo)) = (from_hex(bytes[i + 1]), from_hex(bytes[i + 2])) {
+                out.push((hi << 4) | lo);
+                i += 3;
+                continue;
+            }
+        }
+        out.push(bytes[i]);
+        i += 1;
+    }
+    String::from_utf8(out).ok()
+}
+
+fn from_hex(b: u8) -> Option<u8> {
+    match b {
+        b'0'..=b'9' => Some(b - b'0'),
+        b'a'..=b'f' => Some(b - b'a' + 10),
+        b'A'..=b'F' => Some(b - b'A' + 10),
+        _ => None,
+    }
+}

--- a/src-tauri/src/os_open.rs
+++ b/src-tauri/src/os_open.rs
@@ -98,10 +98,10 @@ pub fn take_opened_paths(queue: State<'_, Mutex<OpenedPathQueue>>) -> Vec<String
 }
 
 fn strip_file_scheme(token: &str) -> Option<&str> {
-    if token.len() >= 7 && token[..7].eq_ignore_ascii_case("file://") {
-        Some(&token[7..])
-    } else {
-        None
+    // `get` returns None when 7 is not a char boundary (e.g. `/tmp/报告.pdf`).
+    match token.get(..7) {
+        Some(prefix) if prefix.eq_ignore_ascii_case("file://") => token.get(7..),
+        _ => None,
     }
 }
 
@@ -131,10 +131,15 @@ fn file_url_to_path(after_scheme: &str) -> Option<PathBuf> {
 
 fn strip_localhost_host(after_scheme: &str) -> &str {
     const HOST: &str = "localhost";
-    if after_scheme.len() >= HOST.len() && after_scheme[..HOST.len()].eq_ignore_ascii_case(HOST) {
-        let rest = &after_scheme[HOST.len()..];
-        if rest.is_empty() || rest.starts_with('/') {
-            return rest;
+    // Off-boundary indexes (e.g. `/tmp/报告.pdf`) fall through to the raw path.
+    if after_scheme
+        .get(..HOST.len())
+        .is_some_and(|prefix| prefix.eq_ignore_ascii_case(HOST))
+    {
+        if let Some(rest) = after_scheme.get(HOST.len()..) {
+            if rest.is_empty() || rest.starts_with('/') {
+                return rest;
+            }
         }
     }
     after_scheme

--- a/src-tauri/src/os_open_tests.rs
+++ b/src-tauri/src/os_open_tests.rs
@@ -1,13 +1,4 @@
-//! Unit tests for `crate::os_open` (issue #74).
-//!
-//! Named helper: `src-tauri/src/os_open.rs`. The product module may be missing
-//! until impl. Expected public surface:
-//!
-//! - `parse_opened_argv(args: impl IntoIterator<Item = impl AsRef<str>>) -> Vec<PathBuf>`
-//!   skips argv[0], then maps the rest through `parse_opened_token`.
-//! - `parse_opened_token(token: &str) -> Option<PathBuf>`
-//!   accepts a raw path or `file://` (percent-decoded); drops `-flag`s and
-//!   non-file URLs. Does not read file bytes.
+//! Unit tests for `crate::os_open` argv / `file://` parsing (issue #74).
 
 use std::path::PathBuf;
 
@@ -84,5 +75,44 @@ fn os_open_parse_skip_flags_and_urls() {
         token("offpdf"),
         None,
         "os-open-parse-skip-flags-and-urls: a bare argv[0]-like token is not an opened path",
+    );
+}
+
+#[test]
+fn os_open_parse_utf8_cjk_tmp() {
+    assert_eq!(
+        token("/tmp/报告.pdf"),
+        Some(PathBuf::from("/tmp/报告.pdf")),
+        "R-UTF8: raw /tmp/报告.pdf must become Some without slicing at a non-char boundary",
+    );
+}
+
+#[test]
+fn os_open_parse_utf8_cjk_home() {
+    assert_eq!(
+        token("/home/用户/a.pdf"),
+        Some(PathBuf::from("/home/用户/a.pdf")),
+        "R-UTF8: raw /home/用户/a.pdf must become Some without slicing at a non-char boundary",
+    );
+}
+
+#[test]
+fn os_open_parse_utf8_file_url_cjk() {
+    assert_eq!(
+        token("file:///tmp/报告.pdf"),
+        Some(PathBuf::from("/tmp/报告.pdf")),
+        "R-UTF8: unencoded file:///tmp/报告.pdf must decode to /tmp/报告.pdf without panic",
+    );
+}
+
+#[test]
+fn os_open_parse_utf8_cjk_argv() {
+    assert_eq!(
+        argv(&["offpdf", "/tmp/报告.pdf", "/home/用户/a.pdf"]),
+        vec![
+            PathBuf::from("/tmp/报告.pdf"),
+            PathBuf::from("/home/用户/a.pdf"),
+        ],
+        "R-UTF8: argv CJK paths must survive parse_opened_argv",
     );
 }

--- a/src-tauri/src/os_open_tests.rs
+++ b/src-tauri/src/os_open_tests.rs
@@ -1,0 +1,88 @@
+//! Unit tests for `crate::os_open` (issue #74).
+//!
+//! Named helper: `src-tauri/src/os_open.rs`. The product module may be missing
+//! until impl. Expected public surface:
+//!
+//! - `parse_opened_argv(args: impl IntoIterator<Item = impl AsRef<str>>) -> Vec<PathBuf>`
+//!   skips argv[0], then maps the rest through `parse_opened_token`.
+//! - `parse_opened_token(token: &str) -> Option<PathBuf>`
+//!   accepts a raw path or `file://` (percent-decoded); drops `-flag`s and
+//!   non-file URLs. Does not read file bytes.
+
+use std::path::PathBuf;
+
+fn argv(args: &[&str]) -> Vec<PathBuf> {
+    let owned: Vec<String> = args.iter().map(|s| (*s).to_string()).collect();
+    crate::os_open::parse_opened_argv(owned)
+}
+
+fn token(s: &str) -> Option<PathBuf> {
+    crate::os_open::parse_opened_token(s)
+}
+
+#[test]
+fn os_open_parse_argv_plain() {
+    assert_eq!(
+        argv(&["offpdf", "/tmp/a.pdf"]),
+        vec![PathBuf::from("/tmp/a.pdf")],
+        "os-open-parse-argv-plain: /tmp/a.pdf must become an opened path",
+    );
+    assert_eq!(
+        argv(&[
+            "/Applications/OffPDF.app/Contents/MacOS/offpdf",
+            "/tmp/a.pdf",
+            "/tmp/b.png",
+        ]),
+        vec![PathBuf::from("/tmp/a.pdf"), PathBuf::from("/tmp/b.png")],
+        "os-open-parse-argv-plain: every trailing path must be kept",
+    );
+}
+
+#[test]
+fn os_open_parse_spaces_unicode() {
+    assert_eq!(
+        token("/tmp/ünicode 报告.pdf"),
+        Some(PathBuf::from("/tmp/ünicode 报告.pdf")),
+        "os-open-parse-spaces-unicode: raw path with spaces and non-ASCII must survive",
+    );
+    assert_eq!(
+        token("file:///tmp/my%20file.pdf"),
+        Some(PathBuf::from("/tmp/my file.pdf")),
+        "os-open-parse-spaces-unicode: file:// percent-decode must yield /tmp/my file.pdf",
+    );
+    assert_eq!(
+        token("file:///tmp/%C3%BCnicode%20%E6%8A%A5%E5%91%8A.pdf"),
+        Some(PathBuf::from("/tmp/ünicode 报告.pdf")),
+        "os-open-parse-spaces-unicode: file:// percent-decode must yield /tmp/ünicode 报告.pdf",
+    );
+}
+
+#[test]
+fn os_open_parse_skip_flags_and_urls() {
+    assert_eq!(
+        argv(&[
+            "offpdf",
+            "-flag",
+            "--help",
+            "https://example.com/a.pdf",
+            "/tmp/a.pdf",
+        ]),
+        vec![PathBuf::from("/tmp/a.pdf")],
+        "os-open-parse-skip-flags-and-urls: drop argv[0], -flag, and https://",
+    );
+    assert_eq!(
+        token("-flag"),
+        None,
+        "os-open-parse-skip-flags-and-urls: -flag is not an opened path",
+    );
+    assert_eq!(
+        token("https://example.com/a.pdf"),
+        None,
+        "os-open-parse-skip-flags-and-urls: https:// is not an opened path",
+    );
+    assert_eq!(
+        token("offpdf"),
+        None,
+        "os-open-parse-skip-flags-and-urls: a bare argv[0]-like token is not an opened path",
+    );
+}

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -61,7 +61,30 @@
     "macOS": {
       "minimumSystemVersion": "11.0",
       "hardenedRuntime": true
-    }
+    },
+    "fileAssociations": [
+      { "ext": ["pdf"], "mimeType": "application/pdf", "name": "PDF Document", "role": "Editor", "rank": "Alternate" },
+      { "ext": ["png"], "mimeType": "image/png", "name": "PNG Image", "role": "Editor", "rank": "Alternate" },
+      { "ext": ["jpg", "jpeg"], "mimeType": "image/jpeg", "name": "JPEG Image", "role": "Editor", "rank": "Alternate" },
+      { "ext": ["gif"], "mimeType": "image/gif", "name": "GIF Image", "role": "Editor", "rank": "Alternate" },
+      { "ext": ["bmp"], "mimeType": "image/bmp", "name": "Bitmap Image", "role": "Editor", "rank": "Alternate" },
+      { "ext": ["webp"], "mimeType": "image/webp", "name": "WebP Image", "role": "Editor", "rank": "Alternate" },
+      { "ext": ["tif", "tiff"], "mimeType": "image/tiff", "name": "TIFF Image", "role": "Editor", "rank": "Alternate" },
+      { "ext": ["heic"], "mimeType": "image/heic", "name": "HEIC Image", "role": "Editor", "rank": "Alternate" },
+      { "ext": ["heif"], "mimeType": "image/heif", "name": "HEIF Image", "role": "Editor", "rank": "Alternate" },
+      { "ext": ["doc"], "mimeType": "application/msword", "name": "Word Document", "role": "Editor", "rank": "Alternate" },
+      { "ext": ["docx"], "mimeType": "application/vnd.openxmlformats-officedocument.wordprocessingml.document", "name": "Word Document", "role": "Editor", "rank": "Alternate" },
+      { "ext": ["xls"], "mimeType": "application/vnd.ms-excel", "name": "Excel Spreadsheet", "role": "Editor", "rank": "Alternate" },
+      { "ext": ["xlsx"], "mimeType": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", "name": "Excel Spreadsheet", "role": "Editor", "rank": "Alternate" },
+      { "ext": ["ppt"], "mimeType": "application/vnd.ms-powerpoint", "name": "PowerPoint Presentation", "role": "Editor", "rank": "Alternate" },
+      { "ext": ["pptx"], "mimeType": "application/vnd.openxmlformats-officedocument.presentationml.presentation", "name": "PowerPoint Presentation", "role": "Editor", "rank": "Alternate" },
+      { "ext": ["odt"], "mimeType": "application/vnd.oasis.opendocument.text", "name": "OpenDocument Text", "role": "Editor", "rank": "Alternate" },
+      { "ext": ["ods"], "mimeType": "application/vnd.oasis.opendocument.spreadsheet", "name": "OpenDocument Spreadsheet", "role": "Editor", "rank": "Alternate" },
+      { "ext": ["odp"], "mimeType": "application/vnd.oasis.opendocument.presentation", "name": "OpenDocument Presentation", "role": "Editor", "rank": "Alternate" },
+      { "ext": ["rtf"], "mimeType": "application/rtf", "name": "Rich Text", "role": "Editor", "rank": "Alternate" },
+      { "ext": ["csv"], "mimeType": "text/csv", "name": "CSV", "role": "Editor", "rank": "Alternate" },
+      { "ext": ["htm", "html"], "mimeType": "text/html", "name": "HTML Document", "role": "Editor", "rank": "Alternate" }
+    ]
   },
   "plugins": {}
 }

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -1,7 +1,76 @@
+import { useEffect } from "react";
 import { Outlet } from "react-router-dom";
 import { Sidebar } from "./Sidebar";
+import { useToast } from "@/components/ui/Toast";
+import { isTauriRuntime } from "@/lib/tauriEnv";
+import { onOpenedPaths, takeOpenedPaths } from "@/lib/tauriCommands";
+import { useWorkspace, type AddResult } from "@/state/workspaceStore";
+
+function reportIntake(
+  toast: (input: {
+    title: string;
+    description?: string;
+    variant?: "success" | "error" | "info";
+  }) => void,
+  result: AddResult,
+) {
+  if (result.notPdf) {
+    toast({ title: "Only PDF, image, or Office files are supported", variant: "error" });
+  }
+  if (result.errors.length) {
+    toast({
+      title: "Some files could not be added",
+      description: result.errors.join(" · "),
+      variant: "error",
+    });
+  }
+  if (result.invalid.length) {
+    toast({
+      title: result.invalid.length === 1 ? "That file is not a valid PDF" : "Some files are not valid PDFs",
+      description: result.invalid.join(", "),
+      variant: "error",
+    });
+  }
+}
 
 export function AppShell() {
+  const { toast } = useToast();
+
+  useEffect(() => {
+    if (!isTauriRuntime()) return;
+    let cancelled = false;
+    let unlisten: (() => void) | undefined;
+
+    const apply = async (paths: string[]) => {
+      if (!paths.length || cancelled) return;
+      // Neutral workspace intake only — do not start a tool or change route.
+      const result = await useWorkspace.getState().addPaths(paths);
+      if (!cancelled) reportIntake(toast, result);
+    };
+
+    void (async () => {
+      try {
+        const stop = await onOpenedPaths((paths) => {
+          void apply(paths);
+        });
+        if (cancelled) {
+          stop();
+          return;
+        }
+        unlisten = stop;
+        const pending = await takeOpenedPaths();
+        await apply(pending);
+      } catch {
+        // Browser / missing IPC — in-app picker still works.
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+      unlisten?.();
+    };
+  }, [toast]);
+
   return (
     <div className="app-shell">
       <Sidebar />

--- a/src/lib/fileTypes.test.ts
+++ b/src/lib/fileTypes.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   isImagePath,
@@ -129,5 +131,70 @@ describe("isSupportedPath", () => {
   it("rejects near misses where a supported extension is not the last one", () => {
     expect(isSupportedPath("report.pdf.exe")).toBe(false);
     expect(isSupportedPath("photo.heic.tmp")).toBe(false);
+  });
+
+  it("accepts spaces and non-ASCII characters in the path", () => {
+    expect(isSupportedPath("/tmp/ünicode 报告.pdf")).toBe(true);
+    expect(isSupportedPath("/tmp/my file.pdf")).toBe(true);
+    expect(isSupportedPath("C:\\Temp\\ünicode 报告.PDF")).toBe(true);
+  });
+});
+
+const SUPPORTED_EXTENSIONS = [...IMAGE_EXTENSIONS, "pdf", ...OFFICE_EXTENSIONS];
+
+type FileAssociation = {
+  ext?: string | string[];
+  rank?: string;
+};
+
+function registeredAssociationExts(associations: FileAssociation[]): string[] {
+  const out: string[] = [];
+  for (const item of associations) {
+    const raw = item.ext;
+    const list = typeof raw === "string" ? [raw] : raw ?? [];
+    for (const ext of list) {
+      out.push(String(ext).replace(/^\./, "").toLowerCase());
+    }
+  }
+  return out;
+}
+
+describe("os-open-associations-match-filetypes", () => {
+  it("registers exactly the isSupportedPath extensions as Open With (rank Alternate)", () => {
+    const tauriConf = JSON.parse(
+      readFileSync(join(process.cwd(), "src-tauri/tauri.conf.json"), "utf8"),
+    ) as { bundle?: { fileAssociations?: FileAssociation[] } };
+    const associations = tauriConf.bundle?.fileAssociations;
+
+    expect(
+      Array.isArray(associations),
+      "os-open-associations-match-filetypes: bundle.fileAssociations must exist",
+    ).toBe(true);
+
+    const list = associations as FileAssociation[];
+    expect(
+      list.length,
+      "os-open-associations-match-filetypes: bundle.fileAssociations must not be empty",
+    ).toBeGreaterThan(0);
+
+    for (const item of list) {
+      expect(
+        item.rank,
+        "os-open-associations-match-filetypes: every association must be rank Alternate (Open With, not silent default)",
+      ).toBe("Alternate");
+    }
+
+    const registered = registeredAssociationExts(list);
+    expect(
+      new Set(registered),
+      "os-open-associations-match-filetypes: registered ext list must match isSupportedPath",
+    ).toEqual(new Set(SUPPORTED_EXTENSIONS));
+
+    for (const ext of registered) {
+      expect(isSupportedPath(`file.${ext}`)).toBe(true);
+    }
+    for (const ext of SUPPORTED_EXTENSIONS) {
+      expect(registered).toContain(ext);
+    }
   });
 });

--- a/src/lib/tauriCommands.ts
+++ b/src/lib/tauriCommands.ts
@@ -86,6 +86,20 @@ export function getTempDir(): Promise<string> {
   return invoke<string>("get_temp_dir");
 }
 
+/** Drain OS-opened paths queued before the frontend listener was ready. */
+export function takeOpenedPaths(): Promise<string[]> {
+  return invoke<string[]>("take_opened_paths");
+}
+
+/** Subscribe to later Open With / second-instance paths (paths only). */
+export async function onOpenedPaths(
+  handler: (paths: string[]) => void,
+): Promise<UnlistenFn> {
+  return listen<string[]>("os-open:paths", (event) => {
+    handler(event.payload ?? []);
+  });
+}
+
 /** Copy a file to a new path; returns the destination path. */
 export function copyFile(src: string, dst: string): Promise<string> {
   return invoke<string>("copy_file", { src, dst });

--- a/src/node-test-shims.d.ts
+++ b/src/node-test-shims.d.ts
@@ -1,0 +1,10 @@
+/** Minimal Node typings so locked tests can read tauri.conf.json. */
+declare module "node:fs" {
+  export function readFileSync(path: string, encoding: string): string;
+}
+
+declare module "node:path" {
+  export function join(...parts: string[]): string;
+}
+
+declare const process: { cwd(): string };

--- a/src/state/workspaceStore.test.ts
+++ b/src/state/workspaceStore.test.ts
@@ -4,6 +4,11 @@ const commands = vi.hoisted(() => ({
   getFileInfo: vi.fn(),
   imageToPdf: vi.fn(),
   officeToPdf: vi.fn(),
+  copyFile: vi.fn(),
+  mergePdfs: vi.fn(),
+  compressPdf: vi.fn(),
+  editPdf: vi.fn(),
+  editPdfOverlays: vi.fn(),
 }));
 
 vi.mock("@/lib/tauriCommands", () => commands);
@@ -112,5 +117,77 @@ describe("workspace image imports", () => {
     expect(result.errors).toEqual(["bad.heic: The image is incomplete."]);
     expect(useWorkspace.getState().files).toHaveLength(1);
     expect(useWorkspace.getState().loading).toBe(false);
+  });
+});
+
+describe("OS-open workspace intake", () => {
+  it("rejects OS-open of report.pdf.exe and .zip without adding them", async () => {
+    const result = await useWorkspace
+      .getState()
+      .addPaths(["/tmp/report.pdf.exe", "/tmp/archive.zip"]);
+
+    expect(result.added).toBe(0);
+    expect(result.notPdf).toBe(true);
+    expect(result.errors).toEqual([]);
+    expect(useWorkspace.getState().files).toHaveLength(0);
+    expect(commands.getFileInfo).not.toHaveBeenCalled();
+    expect(commands.copyFile).not.toHaveBeenCalled();
+    expect(commands.mergePdfs).not.toHaveBeenCalled();
+    expect(commands.compressPdf).not.toHaveBeenCalled();
+    expect(commands.editPdf).not.toHaveBeenCalled();
+    expect(commands.editPdfOverlays).not.toHaveBeenCalled();
+  });
+
+  it("keeps a supported path when mixed with unsupported OS-open files", async () => {
+    const result = await useWorkspace
+      .getState()
+      .addPaths(["/tmp/report.pdf.exe", "/tmp/opened.pdf", "/tmp/archive.zip"]);
+
+    expect(result.added).toBe(1);
+    expect(result.notPdf).toBe(true);
+    expect(result.errors).toEqual([]);
+    expect(useWorkspace.getState().files).toHaveLength(1);
+    expect(useWorkspace.getState().files[0]?.path).toBe("/tmp/opened.pdf");
+    expect(commands.getFileInfo).toHaveBeenCalledTimes(1);
+    expect(commands.getFileInfo).toHaveBeenCalledWith("/tmp/opened.pdf");
+  });
+
+  it("collects a missing OS-open path as an error and does not write a dest", async () => {
+    commands.getFileInfo.mockRejectedValueOnce({
+      code: "IO",
+      title: "Could not read file",
+      message: "Could not read file information.",
+    });
+
+    const missing = "/tmp/does-not-exist-os-open.pdf";
+    const result = await useWorkspace.getState().addPaths([missing]);
+
+    expect(result.added).toBe(0);
+    expect(result.notPdf).toBe(false);
+    expect(result.errors).toEqual([
+      "does-not-exist-os-open.pdf: Could not read file information.",
+    ]);
+    expect(useWorkspace.getState().files).toHaveLength(0);
+    expect(commands.copyFile).not.toHaveBeenCalled();
+    expect(commands.mergePdfs).not.toHaveBeenCalled();
+    expect(commands.compressPdf).not.toHaveBeenCalled();
+    expect(commands.editPdf).not.toHaveBeenCalled();
+    expect(commands.editPdfOverlays).not.toHaveBeenCalled();
+    expect(commands.imageToPdf).not.toHaveBeenCalled();
+    expect(commands.officeToPdf).not.toHaveBeenCalled();
+  });
+
+  it("OS-open intake addPaths does not start merge, compress, or redact", async () => {
+    const result = await useWorkspace.getState().addPaths(["/tmp/opened.pdf"]);
+
+    expect(result.added).toBe(1);
+    expect(result.notPdf).toBe(false);
+    expect(result.errors).toEqual([]);
+    expect(commands.getFileInfo).toHaveBeenCalledWith("/tmp/opened.pdf");
+    expect(commands.mergePdfs).not.toHaveBeenCalled();
+    expect(commands.compressPdf).not.toHaveBeenCalled();
+    expect(commands.editPdf).not.toHaveBeenCalled();
+    expect(commands.editPdfOverlays).not.toHaveBeenCalled();
+    expect(commands.copyFile).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

Lets Finder, Explorer, and the Linux desktop send a PDF (or an already-supported image/Office file) to OffPDF via Open With. Files land in the existing workspace. No tool starts. If OffPDF is already running, the same window is focused.

Register as Open With only (`rank: Alternate`), not the silent default PDF handler. Paths with spaces and non-ASCII are kept. Unsupported files show a normal in-app error.

Fixes #74

## Test plan

- [x] `npm test` / typecheck / `cargo test --lib`
- [x] Finder Open With a PDF (cold start) — file appears, no job starts
- [x] Open With a second PDF while already running — same window, stay on current page
- [x] Path with spaces / non-ASCII
- [x] Unsupported `.zip` — error toast, app stays open