### PR TITLE
feat(home): add keyboard-first tool search above the category pills

### DIFF
--- a/src/components/home/HomeToolsSection.test.tsx
+++ b/src/components/home/HomeToolsSection.test.tsx
@@ -1,0 +1,134 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { TOOLS } from "@/lib/tools";
+import { HomeToolsSection } from "./HomeToolsSection";
+
+const FEATURED_IDS = new Set(["merge", "compress", "reorder"]);
+const noop = () => {};
+
+function renderSection(query: string, category: "All" | "Convert" | "Organize" = "All") {
+  return renderToStaticMarkup(
+    <HomeToolsSection
+      query={query}
+      onQueryChange={noop}
+      category={category}
+      onCategory={noop}
+      onOpen={noop}
+    />,
+  );
+}
+
+function getAttribute(tag: string, name: string) {
+  return tag.match(new RegExp(`\\s${name}="([^"]+)"`))?.[1];
+}
+
+function classIndex(markup: string, className: string) {
+  const match = markup.match(new RegExp(`class="[^"]*\\b${className}\\b[^"]*"`));
+  return match ? markup.indexOf(match[0]) : -1;
+}
+
+function toolSearchInput(markup: string) {
+  const searchIndex = classIndex(markup, "tool-search");
+  const pillsIndex = classIndex(markup, "category-pills");
+  if (searchIndex < 0 || pillsIndex < 0 || pillsIndex <= searchIndex) return "";
+  return markup.slice(searchIndex, pillsIndex).match(/<input\b[^>]*>/)?.[0] ?? "";
+}
+
+function labelledText(markup: string, id: string) {
+  const labelled = markup.match(new RegExp(`\\sid="${id}"[^>]*>([^<]*)`));
+  if (labelled?.[1]?.trim()) return labelled[1].trim();
+  const forLabel = markup.match(new RegExp(`<label[^>]*\\sfor="${id}"[^>]*>([\\s\\S]*?)</label>`));
+  return forLabel ? forLabel[1].replace(/<[^>]+>/g, "").trim() : "";
+}
+
+function inputAccessibleName(markup: string, inputTag: string) {
+  const ariaLabel = getAttribute(inputTag, "aria-label")?.trim();
+  if (ariaLabel) return ariaLabel;
+
+  const labelledBy = getAttribute(inputTag, "aria-labelledby");
+  if (labelledBy) {
+    const fromId = labelledText(markup, labelledBy);
+    if (fromId) return fromId;
+  }
+
+  const id = getAttribute(inputTag, "id");
+  if (id) {
+    const fromFor = labelledText(markup, id);
+    if (fromFor) return fromFor;
+  }
+
+  const wrap = markup.match(new RegExp(`<label\\b[^>]*>([\\s\\S]*?)${inputTag.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`));
+  return wrap ? wrap[1].replace(/<[^>]+>/g, "").trim() : "";
+}
+
+function controlAccessibleName(tag: string, inner: string, markup: string) {
+  const ariaLabel = getAttribute(tag, "aria-label")?.trim();
+  if (ariaLabel) return ariaLabel;
+  const labelledBy = getAttribute(tag, "aria-labelledby");
+  if (labelledBy) {
+    const fromId = labelledText(markup, labelledBy);
+    if (fromId) return fromId;
+  }
+  return inner.replace(/<[^>]+>/g, "").trim();
+}
+
+function clearControls(markup: string) {
+  const buttons = [...markup.matchAll(/<button\b([^>]*)>([\s\S]*?)<\/button>/g)].map(([, attrs, inner]) =>
+    controlAccessibleName(`<button${attrs}>`, inner, markup),
+  );
+  const roleButtons = [...markup.matchAll(/<([a-z]+)([^>]*\srole="button"[^>]*)>([\s\S]*?)<\/\1>/gi)].map(
+    ([, , attrs, inner]) => controlAccessibleName(`<x${attrs}>`, inner, markup),
+  );
+  const inputs = [...markup.matchAll(/<input\b[^>]*>/g)]
+    .map(([tag]) => tag)
+    .filter((tag) => /^(button|reset)$/i.test(getAttribute(tag, "type") ?? ""))
+    .map((tag) => controlAccessibleName(tag, "", markup));
+  return [...buttons, ...roleButtons, ...inputs].filter((name) => /clear/i.test(name));
+}
+
+describe("HomeToolsSection", () => {
+  it("HS-FIELD: search input inside .tool-search appears above .category-pills", () => {
+    const markup = renderSection("");
+    const searchIndex = classIndex(markup, "tool-search");
+    const pillsIndex = classIndex(markup, "category-pills");
+
+    expect(searchIndex).toBeGreaterThan(-1);
+    expect(pillsIndex).toBeGreaterThan(searchIndex);
+    expect(toolSearchInput(markup)).toMatch(/<input\b/);
+  });
+
+  it("HS-LABEL: the search input has a non-empty accessible name", () => {
+    const markup = renderSection("");
+    const input = toolSearchInput(markup);
+    expect(input).toMatch(/<input\b/);
+    expect(inputAccessibleName(markup, input).length).toBeGreaterThan(0);
+  });
+
+  it("HS-SSR-EMPTY: empty query + All still has featured-strip and non-featured tool names", () => {
+    const markup = renderSection("");
+    const nonFeatured = TOOLS.filter((tool) => !FEATURED_IDS.has(tool.id));
+
+    expect(classIndex(markup, "featured-strip")).toBeGreaterThan(-1);
+    expect(nonFeatured.length).toBeGreaterThan(0);
+    for (const tool of nonFeatured) {
+      expect(markup).toContain(tool.name);
+    }
+  });
+
+  it('HS-SSR-FILTER: query "docx" shows Office / HTML to PDF and hides Unlock PDF', () => {
+    const markup = renderSection("docx");
+    expect(markup).toContain("Office / HTML to PDF");
+    expect(markup).not.toContain("Unlock PDF");
+  });
+
+  it('HS-SSR-EMPTY-STATE: nonsense query has a no-results node and no .tool-card', () => {
+    const markup = renderSection("zzzxxyyzz");
+    expect(markup).toMatch(/class="[^"]*no-results[^"]*"/);
+    expect(classIndex(markup, "tool-card")).toBe(-1);
+  });
+
+  it("HS-CLEAR-CONTROL: non-empty query exposes a /clear/i control; empty query does not", () => {
+    expect(clearControls(renderSection("docx")).length).toBeGreaterThan(0);
+    expect(clearControls(renderSection(""))).toEqual([]);
+  });
+});

--- a/src/components/home/HomeToolsSection.tsx
+++ b/src/components/home/HomeToolsSection.tsx
@@ -1,0 +1,182 @@
+import { useRef, type KeyboardEvent, type MutableRefObject, type Ref } from "react";
+import { Icon } from "@/components/ui/Icon";
+import { homeSearchEscapeAction } from "@/lib/homeSearchEscape";
+import { homeToolsView } from "@/lib/homeToolsView";
+import { CATEGORIES, TOOLS, type ToolCategory, type ToolMeta } from "@/lib/tools";
+
+type CategoryFilter = ToolCategory | "All";
+
+const FILTERS: CategoryFilter[] = ["All", ...CATEGORIES];
+const FILTER_LABEL: Record<CategoryFilter, string> = {
+  All: "All",
+  Organize: "Organize",
+  Convert: "Convert",
+  "Optimize & secure": "Secure",
+};
+const CATEGORY_CLASS: Record<ToolCategory, string> = {
+  Organize: "organize",
+  Convert: "convert",
+  "Optimize & secure": "optimize",
+};
+
+const CATEGORY_COUNTS: Record<ToolCategory, number> = {
+  Organize: 0,
+  Convert: 0,
+  "Optimize & secure": 0,
+};
+for (const tool of TOOLS) {
+  CATEGORY_COUNTS[tool.category] += 1;
+}
+
+function categoryClass(tool: ToolMeta) {
+  return CATEGORY_CLASS[tool.category];
+}
+
+function ToolButton({ tool, onOpen }: { tool: ToolMeta; onOpen: (path: string) => void }) {
+  return (
+    <button
+      type="button"
+      className={`tool-card tool-card--${categoryClass(tool)}`}
+      onClick={() => onOpen(tool.path)}
+      title={tool.description}
+    >
+      <span className="tool-card__icon">
+        <Icon name={tool.icon} size={22} />
+      </span>
+      <span className="tool-card__text">
+        <span className="tool-card__name">{tool.name}</span>
+        <span className="tool-card__desc">{tool.description}</span>
+      </span>
+    </button>
+  );
+}
+
+function FeaturedTool({ tool, onOpen }: { tool: ToolMeta; onOpen: (path: string) => void }) {
+  return (
+    <button
+      type="button"
+      className={`featured-tool featured-tool--${categoryClass(tool)}`}
+      onClick={() => onOpen(tool.path)}
+      title={tool.description}
+    >
+      <span className="featured-tool__icon">
+        <Icon name={tool.icon} size={24} />
+      </span>
+      <span className="featured-tool__text">
+        <span className="featured-tool__name">{tool.name}</span>
+        <span className="featured-tool__desc">{tool.description}</span>
+      </span>
+      <Icon name="arrowRight" size={16} className="featured-tool__go" />
+    </button>
+  );
+}
+
+export function HomeToolsSection({
+  query,
+  onQueryChange,
+  category,
+  onCategory,
+  onOpen,
+  inputRef,
+}: {
+  query: string;
+  onQueryChange: (query: string) => void;
+  category: CategoryFilter;
+  onCategory: (category: CategoryFilter) => void;
+  onOpen: (path: string) => void;
+  inputRef?: Ref<HTMLInputElement>;
+}) {
+  const view = homeToolsView({ tools: TOOLS, query, category });
+  const localInputRef = useRef<HTMLInputElement | null>(null);
+
+  const setSearchInputRef = (node: HTMLInputElement | null) => {
+    localInputRef.current = node;
+    if (typeof inputRef === "function") inputRef(node);
+    else if (inputRef) (inputRef as MutableRefObject<HTMLInputElement | null>).current = node;
+  };
+
+  const focusSearchInput = () => {
+    const fromProp = inputRef && typeof inputRef !== "function" ? inputRef.current : null;
+    (fromProp ?? localInputRef.current)?.focus();
+  };
+
+  const clearSearch = () => {
+    onQueryChange("");
+    focusSearchInput();
+  };
+
+  const onSearchKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    const action = homeSearchEscapeAction(event);
+    if (!action.clear && !action.blur) return;
+    if (action.clear) onQueryChange("");
+    if (action.blur) event.currentTarget.blur();
+  };
+
+  return (
+    <section className="home-tools">
+      <div className="section-label">Tools</div>
+
+      <div className="tool-search">
+        <Icon name="search" size={16} />
+        <input
+          ref={setSearchInputRef}
+          type="search"
+          value={query}
+          onChange={(event) => onQueryChange(event.target.value)}
+          onKeyDown={onSearchKeyDown}
+          aria-label="Search tools"
+          placeholder="Search tools"
+          spellCheck={false}
+          autoComplete="off"
+        />
+        {query ? (
+          <button
+            type="button"
+            className="tool-search__clear"
+            aria-label="Clear search"
+            onMouseDown={(event) => event.preventDefault()}
+            onClick={clearSearch}
+          >
+            <Icon name="x" size={15} />
+          </button>
+        ) : null}
+      </div>
+
+      <div className="category-pills" role="list" aria-label="Tool categories">
+        {FILTERS.map((filter) => {
+          const count = filter === "All" ? TOOLS.length : CATEGORY_COUNTS[filter];
+          return (
+            <button
+              key={filter}
+              type="button"
+              className={`category-pill ${category === filter ? "is-active" : ""}`}
+              onClick={() => onCategory(filter)}
+              aria-pressed={category === filter}
+            >
+              <span>{FILTER_LABEL[filter]}</span>
+              <span>{count}</span>
+            </button>
+          );
+        })}
+      </div>
+
+      {view.featured.length > 0 && (
+        <div className="featured-strip" aria-label="Quick start tools">
+          {view.featured.map((tool) => (
+            <FeaturedTool key={tool.id} tool={tool} onOpen={onOpen} />
+          ))}
+        </div>
+      )}
+
+      {view.noResults ? (
+        <p className="no-results">No tools match your search.</p>
+      ) : (
+        <div className="tool-grid">
+          {view.grid.map((tool) => (
+            <ToolButton key={tool.id} tool={tool} onOpen={onOpen} />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/lib/homeSearchEscape.test.ts
+++ b/src/lib/homeSearchEscape.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest";
+import { homeSearchEscapeAction } from "./homeSearchEscape";
+
+describe("homeSearchEscapeAction", () => {
+  it("HS-ESCAPE: Escape clears then blurs; other keys do not", () => {
+    expect(homeSearchEscapeAction({ key: "Escape" })).toEqual({ clear: true, blur: true });
+    expect(homeSearchEscapeAction({ key: "Enter" })).toEqual({ clear: false, blur: false });
+    expect(homeSearchEscapeAction({ key: "k" })).toEqual({ clear: false, blur: false });
+    expect(homeSearchEscapeAction({ key: "Backspace" })).toEqual({ clear: false, blur: false });
+  });
+});

--- a/src/lib/homeSearchEscape.ts
+++ b/src/lib/homeSearchEscape.ts
@@ -1,0 +1,4 @@
+export function homeSearchEscapeAction(e: { key: string }): { clear: boolean; blur: boolean } {
+  if (e.key === "Escape") return { clear: true, blur: true };
+  return { clear: false, blur: false };
+}

--- a/src/lib/homeSearchHotkey.test.ts
+++ b/src/lib/homeSearchHotkey.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { isHomeSearchFocusHotkey } from "./homeSearchHotkey";
+
+describe("isHomeSearchFocusHotkey", () => {
+  it("HS-HOTKEY: Ctrl+K and Cmd+K are true; plain k and Ctrl+Alt+K are false", () => {
+    expect(isHomeSearchFocusHotkey({ key: "k", ctrlKey: true, metaKey: false, altKey: false })).toBe(true);
+    expect(isHomeSearchFocusHotkey({ key: "K", ctrlKey: true, metaKey: false, altKey: false })).toBe(true);
+    expect(isHomeSearchFocusHotkey({ key: "k", ctrlKey: false, metaKey: true, altKey: false })).toBe(true);
+    expect(isHomeSearchFocusHotkey({ key: "K", ctrlKey: false, metaKey: true, altKey: false })).toBe(true);
+
+    expect(isHomeSearchFocusHotkey({ key: "k", ctrlKey: false, metaKey: false, altKey: false })).toBe(false);
+    expect(isHomeSearchFocusHotkey({ key: "k", ctrlKey: true, metaKey: false, altKey: true })).toBe(false);
+  });
+});

--- a/src/lib/homeSearchHotkey.ts
+++ b/src/lib/homeSearchHotkey.ts
@@ -1,0 +1,8 @@
+export function isHomeSearchFocusHotkey(e: {
+  key: string;
+  ctrlKey: boolean;
+  metaKey: boolean;
+  altKey: boolean;
+}): boolean {
+  return (e.key === "k" || e.key === "K") && (e.ctrlKey || e.metaKey) && !e.altKey;
+}

--- a/src/lib/homeToolsView.test.ts
+++ b/src/lib/homeToolsView.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import { homeToolsView } from "./homeToolsView";
+import { searchTools } from "./toolSearch";
+import { TOOLS } from "./tools";
+
+const FEATURED_IDS = ["merge", "compress", "reorder"] as const;
+
+function ids(tools: { id: string }[]) {
+  return tools.map((tool) => tool.id);
+}
+
+function featuredFromRegistry() {
+  return FEATURED_IDS.map((id) => {
+    const tool = TOOLS.find((entry) => entry.id === id);
+    if (!tool) throw new Error(`TOOLS is missing featured id ${id}`);
+    return tool;
+  });
+}
+
+describe("homeToolsView", () => {
+  it("HS-VIEW-EMPTY-ALL: empty/whitespace + All → featured merge/compress/reorder, grid excludes those ids", () => {
+    const featured = featuredFromRegistry();
+    const rest = TOOLS.filter((tool) => !FEATURED_IDS.includes(tool.id as (typeof FEATURED_IDS)[number]));
+
+    for (const query of ["", "   "]) {
+      const view = homeToolsView({ tools: TOOLS, query, category: "All" });
+      expect(ids(view.featured)).toEqual([...FEATURED_IDS]);
+      expect(view.featured).toEqual(featured);
+      expect(ids(view.grid).some((id) => FEATURED_IDS.includes(id as (typeof FEATURED_IDS)[number]))).toBe(false);
+      expect(view.grid).toEqual(rest);
+      expect(view.noResults).toBe(false);
+    }
+  });
+
+  it('HS-VIEW-EMPTY-CATEGORY: empty + "Convert" → featured [], grid equals searchTools Convert', () => {
+    const view = homeToolsView({ tools: TOOLS, query: "", category: "Convert" });
+    expect(view.featured).toEqual([]);
+    expect(view.grid).toEqual(searchTools(TOOLS, "", "Convert"));
+    expect(view.noResults).toBe(false);
+  });
+
+  it('HS-VIEW-QUERY: query "docx" + All → featured [], grid equals searchTools(docx) and includes officeToPdf', () => {
+    const view = homeToolsView({ tools: TOOLS, query: "docx", category: "All" });
+    expect(view.featured).toEqual([]);
+    expect(view.grid).toEqual(searchTools(TOOLS, "docx"));
+    expect(ids(view.grid)).toContain("officeToPdf");
+    expect(view.noResults).toBe(false);
+  });
+
+  it("HS-VIEW-QUERY-HIDES-FEATURED: non-empty query matching a featured tool hides the strip but keeps the id in the grid", () => {
+    const view = homeToolsView({ tools: TOOLS, query: "merge", category: "All" });
+    expect(view.featured).toEqual([]);
+    expect(ids(view.grid)).toContain("merge");
+    expect(view.grid).toEqual(searchTools(TOOLS, "merge"));
+    expect(view.noResults).toBe(false);
+  });
+
+  it('HS-VIEW-INTERSECT: query "pdf" + Organize → featured [], grid equals searchTools intersection', () => {
+    const view = homeToolsView({ tools: TOOLS, query: "pdf", category: "Organize" });
+    expect(view.featured).toEqual([]);
+    expect(view.grid).toEqual(searchTools(TOOLS, "pdf", "Organize"));
+    expect(view.noResults).toBe(false);
+  });
+
+  it("HS-VIEW-NONE: nonsense query → grid [], noResults true", () => {
+    const view = homeToolsView({ tools: TOOLS, query: "zzzxxyyzz", category: "All" });
+    expect(view.grid).toEqual([]);
+    expect(view.featured).toEqual([]);
+    expect(view.noResults).toBe(true);
+  });
+});

--- a/src/lib/homeToolsView.ts
+++ b/src/lib/homeToolsView.ts
@@ -1,0 +1,40 @@
+import { searchTools } from "./toolSearch";
+import type { ToolCategory, ToolMeta } from "./tools";
+
+const FEATURED_IDS = ["merge", "compress", "reorder"] as const;
+const FEATURED_ID_SET = new Set<string>(FEATURED_IDS);
+
+export type HomeToolsCategory = ToolCategory | "All";
+
+export function homeToolsView({
+  tools,
+  query,
+  category,
+}: {
+  tools: readonly ToolMeta[];
+  query: string;
+  category: HomeToolsCategory;
+}): { featured: ToolMeta[]; grid: ToolMeta[]; noResults: boolean } {
+  if (query.trim() !== "") {
+    const grid = searchTools(tools, query, category);
+    return { featured: [], grid, noResults: grid.length === 0 };
+  }
+
+  if (category === "All") {
+    const featured = FEATURED_IDS.flatMap((id) => {
+      const tool = tools.find((entry) => entry.id === id);
+      return tool ? [tool] : [];
+    });
+    return {
+      featured,
+      grid: tools.filter((tool) => !FEATURED_ID_SET.has(tool.id)),
+      noResults: false,
+    };
+  }
+
+  return {
+    featured: [],
+    grid: searchTools(tools, query, category),
+    noResults: false,
+  };
+}

--- a/src/routes/HomePage.tsx
+++ b/src/routes/HomePage.tsx
@@ -1,5 +1,6 @@
-import { useMemo, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
+import { HomeToolsSection } from "@/components/home/HomeToolsSection";
 import { Card } from "@/components/ui/Card";
 import { Badge } from "@/components/ui/Badge";
 import { Button } from "@/components/ui/Button";
@@ -7,76 +8,17 @@ import { Icon } from "@/components/ui/Icon";
 import { useToast } from "@/components/ui/Toast";
 import { PrivacyBadge } from "@/components/layout/PrivacyBadge";
 import { WorkspaceFilePicker } from "@/components/pdf";
-import { TOOLS, CATEGORIES, getTool, type ToolCategory, type ToolMeta } from "@/lib/tools";
+import { isHomeSearchFocusHotkey } from "@/lib/homeSearchHotkey";
+import { TOOLS, getTool, type ToolCategory } from "@/lib/tools";
 import { useJobsStore } from "@/state/jobsStore";
 import { formatRelativeTime, dirname } from "@/lib/formatBytes";
 import { openPath } from "@/lib/tauriCommands";
 import { toAppError, type RecentJob } from "@/lib/types";
 
-type CategoryFilter = ToolCategory | "All";
-
-const FILTERS: CategoryFilter[] = ["All", ...CATEGORIES];
-const FEATURED_TOOLS = [getTool("merge"), getTool("compress"), getTool("reorder")];
-const FEATURED_TOOL_IDS = new Set(FEATURED_TOOLS.map((tool) => tool.id));
-const FILTER_LABEL: Record<CategoryFilter, string> = {
-  All: "All",
-  Organize: "Organize",
-  Convert: "Convert",
-  "Optimize & secure": "Secure",
-};
-const CATEGORY_CLASS: Record<ToolCategory, string> = {
-  Organize: "organize",
-  Convert: "convert",
-  "Optimize & secure": "optimize",
-};
-
-function categoryClass(tool: ToolMeta) {
-  return CATEGORY_CLASS[tool.category];
-}
-
 function StatusBadge({ status }: { status: RecentJob["status"] }) {
   if (status === "completed") return <Badge variant="success">Completed</Badge>;
   if (status === "failed") return <Badge variant="danger">Failed</Badge>;
   return <Badge variant="warning">Cancelled</Badge>;
-}
-
-function ToolButton({ tool, onOpen }: { tool: ToolMeta; onOpen: (path: string) => void }) {
-  return (
-    <button
-      type="button"
-      className={`tool-card tool-card--${categoryClass(tool)}`}
-      onClick={() => onOpen(tool.path)}
-      title={tool.description}
-    >
-      <span className="tool-card__icon">
-        <Icon name={tool.icon} size={22} />
-      </span>
-      <span className="tool-card__text">
-        <span className="tool-card__name">{tool.name}</span>
-        <span className="tool-card__desc">{tool.description}</span>
-      </span>
-    </button>
-  );
-}
-
-function FeaturedTool({ tool, onOpen }: { tool: ToolMeta; onOpen: (path: string) => void }) {
-  return (
-    <button
-      type="button"
-      className={`featured-tool featured-tool--${categoryClass(tool)}`}
-      onClick={() => onOpen(tool.path)}
-      title={tool.description}
-    >
-      <span className="featured-tool__icon">
-        <Icon name={tool.icon} size={24} />
-      </span>
-      <span className="featured-tool__text">
-        <span className="featured-tool__name">{tool.name}</span>
-        <span className="featured-tool__desc">{tool.description}</span>
-      </span>
-      <Icon name="arrowRight" size={16} className="featured-tool__go" />
-    </button>
-  );
 }
 
 /** Compact, full-width recent-activity strip. Renders nothing when empty. */
@@ -141,27 +83,19 @@ function RecentJobs() {
 
 export function HomePage() {
   const navigate = useNavigate();
-  const [activeFilter, setActiveFilter] = useState<CategoryFilter>("All");
+  const searchInputRef = useRef<HTMLInputElement>(null);
+  const [query, setQuery] = useState("");
+  const [activeFilter, setActiveFilter] = useState<ToolCategory | "All">("All");
 
-  const categoryCounts = useMemo(() => {
-    const counts: Record<ToolCategory, number> = {
-      Organize: 0,
-      Convert: 0,
-      "Optimize & secure": 0,
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (!isHomeSearchFocusHotkey(event)) return;
+      event.preventDefault();
+      searchInputRef.current?.focus();
     };
-    for (const tool of TOOLS) {
-      counts[tool.category] += 1;
-    }
-    return counts;
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
   }, []);
-
-  const filteredTools = useMemo(() => {
-    return TOOLS.filter((tool) => {
-      const inCategory = activeFilter === "All" || tool.category === activeFilter;
-      const isFeaturedDefault = activeFilter === "All" && FEATURED_TOOL_IDS.has(tool.id);
-      return inCategory && !isFeaturedDefault;
-    });
-  }, [activeFilter]);
 
   const openTool = (path: string) => navigate(path);
 
@@ -188,41 +122,14 @@ export function HomePage() {
         <WorkspaceFilePicker selectable={false} />
       </section>
 
-      <section className="home-tools">
-        <div className="section-label">Tools</div>
-
-        <div className="category-pills" role="list" aria-label="Tool categories">
-          {FILTERS.map((filter) => {
-            const count = filter === "All" ? TOOLS.length : categoryCounts[filter];
-            return (
-              <button
-                key={filter}
-                type="button"
-                className={`category-pill ${activeFilter === filter ? "is-active" : ""}`}
-                onClick={() => setActiveFilter(filter)}
-                aria-pressed={activeFilter === filter}
-              >
-                <span>{FILTER_LABEL[filter]}</span>
-                <span>{count}</span>
-              </button>
-            );
-          })}
-        </div>
-
-        {activeFilter === "All" && (
-          <div className="featured-strip" aria-label="Quick start tools">
-            {FEATURED_TOOLS.map((tool) => (
-              <FeaturedTool key={tool.id} tool={tool} onOpen={openTool} />
-            ))}
-          </div>
-        )}
-
-        <div className="tool-grid">
-          {filteredTools.map((tool) => (
-            <ToolButton key={tool.id} tool={tool} onOpen={openTool} />
-          ))}
-        </div>
-      </section>
+      <HomeToolsSection
+        query={query}
+        onQueryChange={setQuery}
+        category={activeFilter}
+        onCategory={setActiveFilter}
+        onOpen={openTool}
+        inputRef={searchInputRef}
+      />
 
       <RecentJobs />
     </div>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -345,21 +345,33 @@ button {
   gap: 14px;
 }
 .tool-search {
-  width: min(300px, 100%);
+  width: 100%;
   display: flex;
   align-items: center;
   gap: 8px;
-  padding: 9px 12px;
-  border: 1px solid var(--border-strong);
+  padding: 11px 14px;
+  border: 1px solid var(--warning);
   border-radius: var(--radius-md);
   background: var(--surface);
   color: var(--text-muted);
   box-shadow: var(--shadow-sm);
 }
 .tool-search:focus-within {
-  border-color: var(--primary);
-  box-shadow: 0 0 0 3px var(--ring);
+  border-color: var(--warning);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--warning) 35%, transparent);
 }
+.tool-search__clear {
+  appearance: none;
+  display: grid;
+  place-items: center;
+  margin: 0;
+  padding: 2px;
+  border: none;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+}
+.tool-search__clear:hover { color: var(--text); }
 .tool-search input {
   width: 100%;
   min-width: 0;
@@ -369,8 +381,17 @@ button {
   color: var(--text);
   font: inherit;
   user-select: text;
+  -webkit-appearance: none;
 }
+.tool-search input::-webkit-search-cancel-button { display: none; }
 .tool-search input::placeholder { color: var(--text-subtle); }
+.no-results {
+  margin: 0;
+  padding: 22px 12px;
+  color: var(--text-muted);
+  text-align: center;
+  font-size: 13.5px;
+}
 .category-pills {
   display: flex;
   gap: 8px;


### PR DESCRIPTION
## Summary

Adds a prominent tool search box on the desktop home screen, above the category pills. It filters the existing 23-tool registry (name, description, category, aliases) via the `searchTools` helper from #92. Ctrl/Cmd+K focuses the field on Home; Escape clears then blurs; a visible clear control clears and keeps focus. Non-empty queries hide the featured strip and show matches in the grid (including Merge/Compress/Reorder when they match). Focus uses the warm/orange accent in both themes.

Fixes #73.

## Why

Home listed 23 tools with category pills only. `.tool-search` styles existed but nothing was wired. Searching tools (not documents or the filesystem) is the remaining half of #73 after #92 landed the matcher.

## Validation

- [x] `npm test` (312 passed)
- [x] `npm run typecheck`
- [x] `cargo test --manifest-path src-tauri/Cargo.toml --lib`
- [x] Manual: type `docx` / `merge`, category ∩ query, no-results, ✕ keeps focus, Escape clears+blurs, ⌘K on Home only, orange focus in light and dark

## Privacy Checklist

- [x] This keeps OffPDF usable offline.
- [x] This does not upload, log, or transmit user files.
- [x] New dependencies or bundled binaries have compatible licenses. (none added)