### PR TITLE
feat(ai): add InferenceBackend trait and deterministic Fake

### DIFF
--- a/src-tauri/src/ai/fake.rs
+++ b/src-tauri/src/ai/fake.rs
@@ -1,0 +1,122 @@
+//! Deterministic in-process Fake. Same prompt after the same load yields
+//! the same UTF-8. Reserved prompts: `FAIL` (structured error) and `SLOW`
+//! (cooperative cancel). No disk model, no child process, no sockets.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::thread;
+use std::time::Duration;
+
+use crate::error::AppError;
+
+use super::{BackendStatus, FakeScript, Health, InferenceBackend};
+
+const BACKEND_ID: &str = "fake";
+const SLOW_SLICE: Duration = Duration::from_millis(10);
+const SLOW_SLICES: u32 = 25;
+
+pub(crate) struct FakeBackend {
+    loaded: AtomicBool,
+    cancel: AtomicBool,
+    unhealthy: bool,
+}
+
+impl FakeBackend {
+    pub(super) fn new(script: Option<FakeScript>) -> Self {
+        Self {
+            loaded: AtomicBool::new(false),
+            cancel: AtomicBool::new(false),
+            unhealthy: matches!(script, Some(FakeScript::Unhealthy)),
+        }
+    }
+
+    fn reply(prompt: &str) -> String {
+        format!("fake:{prompt}")
+    }
+
+    fn take_cancel(&self) -> bool {
+        self.cancel.swap(false, Ordering::SeqCst)
+    }
+
+    pub fn load(&self) -> Result<(), AppError> {
+        self.cancel.store(false, Ordering::SeqCst);
+        self.loaded.store(true, Ordering::SeqCst);
+        Ok(())
+    }
+
+    pub fn unload(&self) -> Result<(), AppError> {
+        self.loaded.store(false, Ordering::SeqCst);
+        self.cancel.store(false, Ordering::SeqCst);
+        Ok(())
+    }
+
+    pub fn generate(&self, prompt: &str) -> Result<String, AppError> {
+        if !self.loaded.load(Ordering::SeqCst) {
+            return Err(AppError::ai_not_ready());
+        }
+
+        if prompt == "FAIL" {
+            return Err(AppError::ai_failed());
+        }
+
+        if prompt == "SLOW" {
+            for _ in 0..SLOW_SLICES {
+                if self.cancel.load(Ordering::SeqCst) {
+                    let _ = self.take_cancel();
+                    return Err(AppError::cancelled());
+                }
+                thread::sleep(SLOW_SLICE);
+            }
+        }
+
+        if self.take_cancel() {
+            return Err(AppError::cancelled());
+        }
+
+        Ok(Self::reply(prompt))
+    }
+
+    pub fn cancel(&self) {
+        self.cancel.store(true, Ordering::SeqCst);
+    }
+
+    pub fn status(&self) -> BackendStatus {
+        if self.loaded.load(Ordering::SeqCst) {
+            BackendStatus::Ready
+        } else {
+            BackendStatus::Unloaded
+        }
+    }
+
+    pub fn health(&self) -> Health {
+        Health {
+            ok: self.loaded.load(Ordering::SeqCst) && !self.unhealthy,
+            backend_id: BACKEND_ID,
+        }
+    }
+}
+
+impl InferenceBackend for FakeBackend {
+    fn load(&self) -> Result<(), AppError> {
+        FakeBackend::load(self)
+    }
+
+    fn unload(&self) -> Result<(), AppError> {
+        FakeBackend::unload(self)
+    }
+
+    fn generate(&self, prompt: &str) -> Result<String, AppError> {
+        FakeBackend::generate(self, prompt)
+    }
+
+    fn cancel(&self) {
+        FakeBackend::cancel(self)
+    }
+
+    fn status(&self) -> BackendStatus {
+        FakeBackend::status(self)
+    }
+
+    fn health(&self) -> Health {
+        FakeBackend::health(self)
+    }
+}

--- a/src-tauri/src/ai/mod.rs
+++ b/src-tauri/src/ai/mod.rs
@@ -1,0 +1,65 @@
+//! Isolation layer for on-device inference.
+//!
+//! Callers use [`InferenceBackend`]. This fold ships only an in-process Fake
+//! so cancel, fail, and health can be exercised without a model file. When a
+//! real backend is added later, keep the Fake injectable so tests still do
+//! not need weights.
+//!
+//! No Tauri commands. Generate is UTF-8 prompt in, UTF-8 text out — not a
+//! document path and not file bytes.
+
+mod fake;
+
+use crate::error::AppError;
+
+use fake::FakeBackend;
+
+/// Load / unload / generate / cancel / status / health. Methods take `&self`
+/// so `cancel` can run from another thread while `generate` is in flight.
+///
+/// This fold's tests call inherent methods on the Fake handle (no trait import).
+#[allow(dead_code)]
+pub trait InferenceBackend: Send + Sync {
+    fn load(&self) -> Result<(), AppError>;
+    fn unload(&self) -> Result<(), AppError>;
+    fn generate(&self, prompt: &str) -> Result<String, AppError>;
+    fn cancel(&self);
+    fn status(&self) -> BackendStatus;
+    fn health(&self) -> Health;
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BackendStatus {
+    Unloaded,
+    Ready,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Health {
+    pub ok: bool,
+    pub backend_id: &'static str,
+}
+
+/// Scripted Fake behaviour set at construction. No model file, no download.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FakeScript {
+    Unhealthy,
+}
+
+fn as_backend<T: InferenceBackend>(backend: T) -> T {
+    backend
+}
+
+/// In-process Fake. No filesystem path, no download.
+///
+/// Returns a crate-visible handle with inherent methods so callers (and
+/// `ai_tests`) do not need the trait in scope. The concrete type lives in
+/// a private submodule and is not re-exported.
+pub(crate) fn fake() -> FakeBackend {
+    as_backend(FakeBackend::new(None))
+}
+
+/// In-process Fake with a scripted health / fail path.
+pub(crate) fn fake_with_script(script: FakeScript) -> FakeBackend {
+    as_backend(FakeBackend::new(Some(script)))
+}

--- a/src-tauri/src/ai_tests.rs
+++ b/src-tauri/src/ai_tests.rs
@@ -1,0 +1,403 @@
+//! Unit tests for `crate::ai` InferenceBackend + Fake (issue #81).
+//!
+//! Public names are the Approach A lock: `ai::fake` / `ai::fake_with_script`,
+//! `InferenceBackend` {load, unload, generate, cancel, status, health},
+//! reserved prompts `FAIL` and `SLOW`, `FakeScript::Unhealthy`.
+//! The `ai` module may be missing until impl; that compile failure is fail-today.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::Duration;
+
+fn manifest_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+fn ai_src_dir() -> PathBuf {
+    manifest_dir().join("src/ai")
+}
+
+fn walk_rs_files(dir: &Path, out: &mut Vec<PathBuf>) {
+    let entries = match std::fs::read_dir(dir) {
+        Ok(entries) => entries,
+        Err(_) => return,
+    };
+    for entry in entries {
+        let path = match entry {
+            Ok(entry) => entry.path(),
+            Err(_) => continue,
+        };
+        if path.is_dir() {
+            walk_rs_files(&path, out);
+        } else if path.extension().is_some_and(|ext| ext == "rs") {
+            out.push(path);
+        }
+    }
+}
+
+fn default_dependency_names(toml: &str) -> Vec<String> {
+    let mut names = Vec::new();
+    let mut in_deps = false;
+    for line in toml.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with('[') {
+            in_deps = trimmed == "[dependencies]";
+            continue;
+        }
+        if !in_deps || trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
+        }
+        if let Some(eq) = trimmed.find('=') {
+            let name = trimmed[..eq].trim();
+            if !name.is_empty() {
+                names.push(name.to_string());
+            }
+        }
+    }
+    names
+}
+
+fn is_banned_runtime_crate(name: &str) -> bool {
+    let lower = name.to_ascii_lowercase();
+    lower.contains("llama")
+        || lower.contains("candle")
+        || lower.contains("reqwest")
+        || lower == "ort"
+        || lower.starts_with("ort-")
+}
+
+fn assert_ai_error_fields(err: &crate::error::AppError, must_id: &str) {
+    assert!(
+        !err.title.is_empty(),
+        "{must_id}: AppError.title must be non-empty"
+    );
+    assert!(
+        !err.message.is_empty(),
+        "{must_id}: AppError.message must be non-empty"
+    );
+}
+
+/// ai-cargo-no-runtime-crate — control; must pass today.
+#[test]
+fn ai_cargo_no_runtime_crate() {
+    let toml_path = manifest_dir().join("Cargo.toml");
+    let toml = std::fs::read_to_string(&toml_path)
+        .unwrap_or_else(|err| panic!("ai-cargo-no-runtime-crate: read {}: {err}", toml_path.display()));
+    let banned: Vec<String> = default_dependency_names(&toml)
+        .into_iter()
+        .filter(|name| is_banned_runtime_crate(name))
+        .collect();
+    assert!(
+        banned.is_empty(),
+        "ai-cargo-no-runtime-crate: default [dependencies] must not add llama / candle / ort / reqwest; found {banned:?}"
+    );
+}
+
+/// ai-no-network-no-shell — fail today if `src/ai/` is missing.
+#[test]
+fn ai_no_network_no_shell() {
+    let ai_dir = ai_src_dir();
+    assert!(
+        ai_dir.is_dir(),
+        "ai-no-network-no-shell: src-tauri/src/ai/ must exist so the source lock can scan it"
+    );
+
+    let mut files = Vec::new();
+    walk_rs_files(&ai_dir, &mut files);
+    assert!(
+        !files.is_empty(),
+        "ai-no-network-no-shell: src-tauri/src/ai/ must contain Rust sources to scan"
+    );
+
+    const FORBIDDEN: &[&str] = &[
+        "reqwest",
+        "ureq",
+        "std::net",
+        "std::process::Command",
+        "XAI_API_KEY",
+        "api.openai.com",
+        "api.x.ai",
+        "api.anthropic.com",
+        "generativelanguage.googleapis.com",
+        "api.groq.com",
+    ];
+
+    let mut hits = Vec::new();
+    for path in &files {
+        let src = std::fs::read_to_string(path).unwrap_or_else(|err| {
+            panic!("ai-no-network-no-shell: read {}: {err}", path.display())
+        });
+        for token in FORBIDDEN {
+            if src.contains(token) {
+                hits.push(format!("{}: {token}", path.display()));
+            }
+        }
+    }
+    assert!(
+        hits.is_empty(),
+        "ai-no-network-no-shell: src-tauri/src/ai/** must not contain network, shell, or cloud-host tokens; found {hits:?}"
+    );
+}
+
+/// ai-no-pdf-bytes-api — generate is a UTF-8 string, not PDF / page bytes.
+#[test]
+fn ai_no_pdf_bytes_api() {
+    let backend = crate::ai::fake();
+    backend
+        .load()
+        .expect("ai-no-pdf-bytes-api: load must succeed without a model file");
+    let prompt: &str = "utf-8 prompt, not pdf bytes";
+    let out = backend
+        .generate(prompt)
+        .expect("ai-no-pdf-bytes-api: generate must take a string prompt");
+    let _utf8: &str = out.as_str();
+
+    let ai_dir = ai_src_dir();
+    assert!(
+        ai_dir.is_dir(),
+        "ai-no-pdf-bytes-api: no generate signature to inspect until src-tauri/src/ai/ exists"
+    );
+    let mut files = Vec::new();
+    walk_rs_files(&ai_dir, &mut files);
+    let mut saw_generate = false;
+    let mut bad = Vec::new();
+    for path in &files {
+        let src = std::fs::read_to_string(path).unwrap_or_else(|err| {
+            panic!("ai-no-pdf-bytes-api: read {}: {err}", path.display())
+        });
+        let mut rest = src.as_str();
+        while let Some(idx) = rest.find("fn generate") {
+            saw_generate = true;
+            let after = &rest[idx..];
+            let end = after.find('{').or_else(|| after.find(';')).unwrap_or(after.len());
+            let sig = &after[..end];
+            for token in ["Vec<u8>", "&[u8]", "PathBuf", "std::path::Path", "DynamicImage"] {
+                if sig.contains(token) {
+                    bad.push(format!("{}: {token}", path.display()));
+                }
+            }
+            rest = &after["fn generate".len()..];
+        }
+    }
+    assert!(
+        saw_generate,
+        "ai-no-pdf-bytes-api: no generate signature to inspect under src-tauri/src/ai/"
+    );
+    assert!(
+        bad.is_empty(),
+        "ai-no-pdf-bytes-api: generate must not take PDF/page bytes or a path; found {bad:?}"
+    );
+}
+
+/// ai-trait-surface — factory handle exposes load, unload, generate, cancel, status, health.
+#[test]
+fn ai_trait_surface() {
+    let backend = crate::ai::fake();
+    let _ = backend.status();
+    let _ = backend.health();
+    backend
+        .load()
+        .expect("ai-trait-surface: load must exist and not fail on Fake");
+    let _ = backend.generate("surface");
+    let _ = backend.cancel();
+    backend
+        .unload()
+        .expect("ai-trait-surface: unload must exist and not fail on Fake");
+}
+
+/// ai-factory-hides-concrete — construct via `ai::fake`, never a llama/candle/ort type.
+#[test]
+fn ai_factory_hides_concrete() {
+    // Construct only via the crate-visible factory. Do not name a llama/candle/ort type.
+    let backend = crate::ai::fake();
+    let _ = backend.status();
+    let scripted = crate::ai::fake_with_script(crate::ai::FakeScript::Unhealthy);
+    let _ = scripted.health();
+
+    let ai_dir = ai_src_dir();
+    if !ai_dir.is_dir() {
+        return;
+    }
+    let mut files = Vec::new();
+    walk_rs_files(&ai_dir, &mut files);
+    let mut hits = Vec::new();
+    for path in &files {
+        let src = std::fs::read_to_string(path).unwrap_or_else(|err| {
+            panic!("ai-factory-hides-concrete: read {}: {err}", path.display())
+        });
+        for line in src.lines() {
+            let trimmed = line.trim();
+            if trimmed.starts_with("pub ")
+                && (trimmed.contains("llama")
+                    || trimmed.contains("candle")
+                    || trimmed.contains("ort::"))
+            {
+                hits.push(format!("{}: {trimmed}", path.display()));
+            }
+        }
+    }
+    assert!(
+        hits.is_empty(),
+        "ai-factory-hides-concrete: ai/** must not pub a llama/candle/ort type; found {hits:?}"
+    );
+}
+
+/// ai-fake-deterministic — same load + same prompt twice → identical UTF-8.
+#[test]
+fn ai_fake_deterministic() {
+    let backend = crate::ai::fake();
+    backend
+        .load()
+        .expect("ai-fake-deterministic: load must succeed without a model file");
+    let prompt = "same prompt twice";
+    let first = backend
+        .generate(prompt)
+        .expect("ai-fake-deterministic: first generate");
+    let second = backend
+        .generate(prompt)
+        .expect("ai-fake-deterministic: second generate");
+    assert_eq!(
+        first, second,
+        "ai-fake-deterministic: same load + same prompt must yield identical UTF-8"
+    );
+    assert_eq!(
+        first.as_bytes(),
+        second.as_bytes(),
+        "ai-fake-deterministic: outputs must be byte-identical"
+    );
+}
+
+/// ai-fake-not-ready — generate before load is AppError, not a panic.
+#[test]
+fn ai_fake_not_ready() {
+    let backend = crate::ai::fake();
+    let err = backend
+        .generate("hello")
+        .expect_err("ai-fake-not-ready: generate before load must return AppError, not Ok");
+    assert_eq!(
+        err.code, "AI_NOT_READY",
+        "ai-fake-not-ready: .code must be the stable AI_NOT_READY"
+    );
+    assert!(
+        err.code.starts_with("AI_"),
+        "ai-fake-not-ready: .code must be an AI_* code, got {}",
+        err.code
+    );
+    assert_ai_error_fields(&err, "ai-fake-not-ready");
+}
+
+/// ai-fake-fail-apperror — reserved prompt FAIL maps to AI_* AppError, not ENGINE_FAILED.
+#[test]
+fn ai_fake_fail_apperror() {
+    let backend = crate::ai::fake();
+    backend
+        .load()
+        .expect("ai-fake-fail-apperror: load must succeed before FAIL");
+    let err = backend
+        .generate("FAIL")
+        .expect_err("ai-fake-fail-apperror: reserved prompt FAIL must return AppError");
+    assert!(
+        err.code.starts_with("AI_"),
+        "ai-fake-fail-apperror: .code must be AI_*, got {}",
+        err.code
+    );
+    assert_ne!(
+        err.code, "ENGINE_FAILED",
+        "ai-fake-fail-apperror: must not reuse the PDF-engine code"
+    );
+    assert_ai_error_fields(&err, "ai-fake-fail-apperror");
+}
+
+/// ai-fake-cancel-cancelled — cancel an in-flight SLOW generate → CANCELLED.
+#[test]
+fn ai_fake_cancel_cancelled() {
+    let backend = Arc::new(crate::ai::fake());
+    backend
+        .load()
+        .expect("ai-fake-cancel-cancelled: load must succeed before SLOW");
+
+    let worker = {
+        let backend = Arc::clone(&backend);
+        std::thread::spawn(move || backend.generate("SLOW"))
+    };
+
+    // SLOW must stay in-flight long enough for cancel to observe it.
+    std::thread::sleep(Duration::from_millis(50));
+    let _ = backend.cancel();
+
+    let result = worker
+        .join()
+        .expect("ai-fake-cancel-cancelled: generate thread must not panic");
+    let err = result.expect_err("ai-fake-cancel-cancelled: cancelled SLOW must be Err");
+    assert_eq!(
+        err.code,
+        crate::error::AppError::cancelled().code,
+        "ai-fake-cancel-cancelled: must reuse AppError::cancelled"
+    );
+    assert_eq!(
+        err.code, "CANCELLED",
+        "ai-fake-cancel-cancelled: .code must be CANCELLED"
+    );
+    assert_ne!(
+        err.code, "ENGINE_FAILED",
+        "ai-fake-cancel-cancelled: must not reuse ENGINE_FAILED"
+    );
+}
+
+/// ai-fake-health-offline — health ok after load, and scripted unhealthy, no model/network.
+#[test]
+fn ai_fake_health_offline() {
+    let backend = crate::ai::fake();
+    backend
+        .load()
+        .expect("ai-fake-health-offline: load must succeed without a model file");
+    let health = backend.health();
+    assert!(
+        health.ok,
+        "ai-fake-health-offline: health after load must be ok without a model file"
+    );
+    assert_eq!(
+        health.backend_id, "fake",
+        "ai-fake-health-offline: backend id must be \"fake\""
+    );
+
+    let unhealthy = crate::ai::fake_with_script(crate::ai::FakeScript::Unhealthy);
+    unhealthy
+        .load()
+        .expect("ai-fake-health-offline: scripted unhealthy load must not need a model");
+    let health = unhealthy.health();
+    assert!(
+        !health.ok,
+        "ai-fake-health-offline: FakeScript::Unhealthy must report not-ok without a model or network"
+    );
+}
+
+/// ai-fake-unload — load → Ready; unload → Unloaded; generate after unload → not-ready.
+#[test]
+fn ai_fake_unload() {
+    let backend = crate::ai::fake();
+    backend
+        .load()
+        .expect("ai-fake-unload: load must succeed without a model file");
+    assert!(
+        matches!(backend.status(), crate::ai::BackendStatus::Ready),
+        "ai-fake-unload: status after load must be Ready"
+    );
+
+    backend
+        .unload()
+        .expect("ai-fake-unload: unload must succeed");
+    assert!(
+        matches!(backend.status(), crate::ai::BackendStatus::Unloaded),
+        "ai-fake-unload: status after unload must be Unloaded"
+    );
+
+    let err = backend
+        .generate("after unload")
+        .expect_err("ai-fake-unload: generate after unload must return AppError");
+    assert_eq!(
+        err.code, "AI_NOT_READY",
+        "ai-fake-unload: generate after unload must be AI_NOT_READY"
+    );
+    assert_ai_error_fields(&err, "ai-fake-unload");
+}

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -104,6 +104,22 @@ impl AppError {
         )
     }
 
+    pub fn ai_not_ready() -> Self {
+        Self::new(
+            "AI_NOT_READY",
+            "Local AI is not ready",
+            "The local inference backend is not loaded.",
+        )
+    }
+
+    pub fn ai_failed() -> Self {
+        Self::new(
+            "AI_FAILED",
+            "Local AI failed",
+            "The local inference backend could not complete this request.",
+        )
+    }
+
     pub fn io(context: &str, err: impl std::fmt::Display) -> Self {
         Self::new(
             "IO_ERROR",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -31,11 +31,15 @@
 //! Jobs (`commands::jobs`):
 //!   - `cancel_job(registry, job_id: String) -> Result<(), AppError>`
 
+mod ai;
 mod commands;
 mod error;
 mod models;
 mod pdf_engine;
 mod utils;
+
+#[cfg(test)]
+mod ai_tests;
 
 use models::JobRegistry;
 


### PR DESCRIPTION
## Summary

Adds a small Rust `InferenceBackend` seam (`load` / `unload` / `generate` / `cancel` / `status` / `health`) plus an in-process deterministic Fake so cancel, fail, and health can be tested without a real model. Product code does not import llama.cpp / candle / ort. No Tauri commands, no network, no model download.

Fixes #81.

## Why

Parent #76 and epic #80 need a place to plug a local runtime later. This fold is the isolation layer only: Fake is UTF-8 prompt → UTF-8 text; `FAIL` / `SLOW` drive `AI_*` and `CANCELLED`. Model store, Settings UI, and PDF ingest stay out.

## Validation

- [x] `cargo test --manifest-path src-tauri/Cargo.toml --lib ai_` (11 passed)
- [x] `npm test` / `npm run typecheck` / `cargo test --lib` on `epic/local-ai-runtime`

## Privacy Checklist

- [x] This keeps OffPDF usable offline.
- [x] This does not upload, log, or transmit user files.
- [x] New dependencies or bundled binaries have compatible licenses. (none added)